### PR TITLE
Add theme toggle and refine layout styling

### DIFF
--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -4,10 +4,12 @@ import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import { useRecipes } from '../../context/RecipeContext';
 import './layout.css';
+import { useTheme } from '../../context/ThemeContext';
 
 const TopBar = () => {
   const { user, logout } = useAuth();
   const { recipes } = useRecipes();
+  const { theme, toggleTheme } = useTheme();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const location = useLocation();
@@ -31,8 +33,17 @@ const TopBar = () => {
   };
 
   useEffect(() => {
+    let ticking = false;
+
     const onScroll = () => {
-      setIsCondensed(window.scrollY > 64);
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          const shouldCondense = window.scrollY > 72;
+          setIsCondensed((prev) => (prev !== shouldCondense ? shouldCondense : prev));
+          ticking = false;
+        });
+        ticking = true;
+      }
     };
 
     onScroll();
@@ -64,6 +75,15 @@ const TopBar = () => {
         </div>
 
         <div className="topbar__actions">
+          <button
+            type="button"
+            onClick={toggleTheme}
+            className="button button--ghost topbar__theme-toggle"
+            aria-label={`Ativar modo ${theme === 'dark' ? 'claro' : 'escuro'}`}
+            title={theme === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro'}
+          >
+            <span aria-hidden="true">{theme === 'dark' ? '🌞' : '🌙'}</span>
+          </button>
           <button type="button" onClick={logout} className="button button--ghost topbar__logout">
             Sair
           </button>

--- a/frontend/src/components/layout/layout.css
+++ b/frontend/src/components/layout/layout.css
@@ -1,6 +1,6 @@
 .app-shell {
-  --shell-padding-y: clamp(1.5rem, 3vw, 2.75rem);
-  --shell-padding-x: clamp(1.2rem, 3vw, 3.2rem);
+  --shell-padding-y: clamp(1.35rem, 2.8vw, 2.6rem);
+  --shell-padding-x: clamp(0.9rem, 2.6vw, 2.2rem);
   display: grid;
   grid-template-columns: 260px minmax(0, 1fr) 340px;
   grid-template-rows: auto minmax(0, 1fr);
@@ -61,7 +61,7 @@ body.chat-focus .app-shell {
   padding: 2rem 1.75rem;
   border-radius: var(--radius-xl);
   background: var(--color-surface);
-  border: 1px solid rgba(255, 255, 255, 0.28);
+  border: 1px solid var(--color-border-strong);
   box-shadow: var(--shadow-xs);
   backdrop-filter: blur(var(--blur-strong));
   transition: width 0.35s cubic-bezier(.4,0,.2,1), min-width 0.35s cubic-bezier(.4,0,.2,1), padding 0.35s cubic-bezier(.4,0,.2,1);
@@ -112,8 +112,8 @@ body.chat-focus .app-shell {
   padding: 0.9rem 1.1rem;
   border-radius: var(--radius-md);
   font-weight: 600;
-  color: rgba(45, 52, 54, 0.6);
-  background: rgba(45, 52, 54, 0.03);
+  color: var(--color-muted);
+  background: var(--color-chip-bg);
   border: 1px solid transparent;
   transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease, border 0.25s ease;
   position: relative;
@@ -167,28 +167,36 @@ body.chat-focus .app-shell {
 
 .topbar__glass {
   width: min(100%, 880px);
-  padding: clamp(1.25rem, 2vw, 2rem) clamp(1.4rem, 3vw, 2.4rem);
+  padding: clamp(1.1rem, 2vw, 1.8rem) clamp(1.2rem, 2.8vw, 2.2rem);
   border-radius: var(--radius-xl);
   background: var(--color-surface);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid var(--color-border-strong);
   box-shadow: var(--shadow-xs);
   backdrop-filter: blur(var(--blur-strong));
   display: grid;
-  gap: 1.2rem;
+  gap: 1.1rem;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    'intro'
+    'stats'
+    'actions'
+    'search';
   transition: padding 0.3s ease, border-radius 0.3s ease, background 0.3s ease;
 }
 
 .topbar--condensed .topbar__glass {
   border-radius: 999px;
-  padding: 0.65rem 1.5rem;
-  grid-template-columns: 1fr auto;
+  padding: 0.55rem 1.2rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas: 'search actions';
   align-items: center;
-  gap: 1.1rem;
+  gap: 0.75rem;
 }
 
 .topbar__intro {
   display: grid;
   gap: 0.4rem;
+  grid-area: intro;
 }
 
 .topbar__greeting {
@@ -208,14 +216,15 @@ body.chat-focus .app-shell {
   align-items: center;
   gap: 0.6rem;
   flex-wrap: wrap;
+  grid-area: stats;
 }
 
 .topbar__badge {
-  background: rgba(45, 52, 54, 0.05);
+  background: var(--color-chip-bg);
   padding: 0.35rem 0.85rem;
   border-radius: 999px;
   font-size: 0.85rem;
-  color: var(--color-muted);
+  color: var(--color-muted-strong);
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
@@ -225,17 +234,21 @@ body.chat-focus .app-shell {
   display: flex;
   gap: 0.6rem;
   flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  grid-area: actions;
 }
 
 .topbar__search {
   display: flex;
   align-items: center;
   gap: 0.85rem;
-  background: rgba(255, 255, 255, 0.78);
-  border: 1px solid rgba(45, 52, 54, 0.06);
+  background: var(--color-search-bg);
+  border: 1px solid var(--color-border-soft);
   border-radius: 999px;
   padding: 0.55rem 0.55rem 0.55rem 1.25rem;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+  box-shadow: inset 0 0 0 1px var(--color-search-glow);
+  grid-area: search;
 }
 
 .topbar__search input {
@@ -258,15 +271,23 @@ body.chat-focus .app-shell {
   padding: 0.5rem 1.2rem;
 }
 
+.topbar__theme-toggle {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  padding: 0;
+  font-size: 1.15rem;
+  min-width: 42px;
+}
+
 .topbar--condensed .topbar__intro,
-.topbar--condensed .topbar__actions {
+.topbar--condensed .topbar__stats {
   display: none;
 }
 
 .topbar--condensed .topbar__search {
-  max-width: 360px;
-  margin-left: auto;
-  border-radius: 999px;
+  max-width: none;
+  margin: 0;
 }
 
 .topbar--condensed .topbar__greeting {
@@ -329,40 +350,32 @@ body.chat-focus .app-shell {
   .topbar__glass {
     border-radius: var(--radius-lg);
   }
-
-  .topbar--condensed .topbar__glass {
-    grid-template-columns: 1fr;
-  }
-
-  .topbar--condensed .topbar__search {
-    max-width: none;
-    margin-left: 0;
-  }
-
-  .topbar {
-    top: 0;
-  }
 }
 
 @media (max-width: 640px) {
   .app-shell {
-    padding: 1.5rem 1.1rem 5rem;
-    gap: 1.4rem;
+    padding: 1.25rem 0.85rem 5rem;
+    gap: 1.3rem;
   }
 
   .topbar__glass {
-    padding: 1.25rem 1.4rem;
-    gap: 1rem;
+    padding: 1.1rem 1.25rem;
+    gap: 0.9rem;
   }
 
   .topbar__search {
     flex-direction: column;
     align-items: stretch;
     border-radius: var(--radius-lg);
+    padding: 0.7rem;
   }
 
   .topbar__search-button,
   .topbar__logout {
     width: 100%;
+  }
+
+  .topbar__actions {
+    justify-content: flex-start;
   }
 }

--- a/frontend/src/components/recipes/RecipeCard.tsx
+++ b/frontend/src/components/recipes/RecipeCard.tsx
@@ -20,8 +20,6 @@ const RecipeCard = ({ recipe, onOpen, onToggleFavorite }: RecipeCardProps) => {
     };
   }, [recipe.coverImage]);
 
-  const isAiCreation = (recipe.source?.importedFrom ?? 'manual') !== 'manual';
-
   return (
     <article className="recipe-card">
       <div className="recipe-card__cover" style={coverStyle}>
@@ -38,7 +36,6 @@ const RecipeCard = ({ recipe, onOpen, onToggleFavorite }: RecipeCardProps) => {
             </svg>
           </span>
         </button>
-        {isAiCreation ? <span className="recipe-card__badge">✨ IA</span> : null}
       </div>
       <div className="recipe-card__content">
         <h3>{recipe.title}</h3>

--- a/frontend/src/components/recipes/recipes.css
+++ b/frontend/src/components/recipes/recipes.css
@@ -9,8 +9,8 @@
   background: var(--color-surface);
   border-radius: 28px;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.36);
-  box-shadow: 0 36px 60px -40px rgba(45, 52, 54, 0.55);
+  border: 1px solid var(--color-border-strong);
+  box-shadow: 0 36px 60px -40px rgba(32, 40, 42, 0.55);
   transition: transform 0.35s cubic-bezier(.22,1,.36,1), box-shadow 0.35s cubic-bezier(.22,1,.36,1);
   position: relative;
 }
@@ -57,9 +57,10 @@
   height: 48px;
   border: none;
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.92);
+  background: var(--color-surface-strong);
+  border: 1px solid var(--color-border-soft);
   backdrop-filter: blur(16px);
-  box-shadow: 0 22px 34px -26px rgba(45, 52, 54, 0.65);
+  box-shadow: 0 22px 34px -26px rgba(32, 40, 42, 0.55);
   cursor: pointer;
   display: grid;
   place-items: center;
@@ -83,35 +84,6 @@
 
 .recipe-card__favorite.is-favorite svg {
   fill: var(--color-primary);
-}
-
-.recipe-card__badge {
-  position: absolute;
-  bottom: 1.4rem;
-  left: 1.4rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.45rem 0.9rem;
-  border-radius: 999px;
-  background: rgba(155, 89, 182, 0.22);
-  color: #402454;
-  font-weight: 600;
-  font-size: 0.85rem;
-  box-shadow: 0 14px 22px -18px rgba(155, 89, 182, 0.75);
-  animation: ia-glow 2.8s infinite;
-}
-
-@keyframes ia-glow {
-  0%,
-  100% {
-    box-shadow: 0 18px 30px -22px rgba(155, 89, 182, 0.65);
-    transform: scale(1);
-  }
-  50% {
-    box-shadow: 0 26px 40px -20px rgba(155, 89, 182, 0.75);
-    transform: scale(1.04);
-  }
 }
 
 .recipe-card__content {
@@ -146,6 +118,8 @@
   justify-content: space-between;
   align-items: center;
   padding: 0  clamp(1.75rem, 3vw, 2.75rem) clamp(1.75rem, 3vw, 2.5rem);
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .recipe-card__cta {
@@ -166,7 +140,7 @@
   padding: 3rem 1rem;
   border: 2px dashed rgba(232, 93, 4, 0.18);
   border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.6);
+  background: var(--color-surface-muted);
 }
 
 @media (max-width: 640px) {
@@ -176,6 +150,8 @@
 
   .recipe-card__actions {
     padding: 0 clamp(1.2rem, 3vw, 2rem) clamp(1.4rem, 3vw, 2rem);
+    flex-direction: column;
+    align-items: stretch;
   }
 }
 

--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -1,0 +1,96 @@
+import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'recipe-ai-theme';
+
+interface ThemeState {
+  theme: Theme;
+  hasStoredPreference: boolean;
+}
+
+const readInitialTheme = (): ThemeState => {
+  if (typeof window === 'undefined') {
+    return { theme: 'light', hasStoredPreference: false };
+  }
+
+  const storedTheme = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+  if (storedTheme === 'light' || storedTheme === 'dark') {
+    if (typeof document !== 'undefined') {
+      document.documentElement.dataset.theme = storedTheme;
+    }
+    return { theme: storedTheme, hasStoredPreference: true };
+  }
+
+  const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+  const resolvedTheme: Theme = prefersDark ? 'dark' : 'light';
+  if (typeof document !== 'undefined') {
+    document.documentElement.dataset.theme = resolvedTheme;
+  }
+  return { theme: resolvedTheme, hasStoredPreference: false };
+};
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [state, setState] = useState<ThemeState>(() => readInitialTheme());
+
+  useEffect(() => {
+    if (state.hasStoredPreference) {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleSystemChange = (event: MediaQueryListEvent) => {
+      setState({ theme: event.matches ? 'dark' : 'light', hasStoredPreference: false });
+    };
+
+    mediaQuery.addEventListener('change', handleSystemChange);
+    return () => mediaQuery.removeEventListener('change', handleSystemChange);
+  }, [state.hasStoredPreference]);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = state.theme;
+    if (state.hasStoredPreference) {
+      window.localStorage.setItem(STORAGE_KEY, state.theme);
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [state]);
+
+  const setTheme = (nextTheme: Theme) => {
+    setState({ theme: nextTheme, hasStoredPreference: true });
+  };
+
+  const toggleTheme = () => {
+    setState((current) => ({
+      theme: current.theme === 'dark' ? 'light' : 'dark',
+      hasStoredPreference: true
+    }));
+  };
+
+  const value = useMemo(
+    () => ({
+      theme: state.theme,
+      toggleTheme,
+      setTheme
+    }),
+    [state.theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,37 +5,80 @@
   font-family: 'Manrope', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.6;
   font-weight: 400;
-  --color-canvas: #f8f7f4;
-  --color-surface: rgba(255, 255, 255, 0.82);
-  --color-surface-strong: rgba(255, 255, 255, 0.92);
-  --color-border: rgba(45, 52, 54, 0.08);
-  --color-text: #2d3436;
-  --color-muted: rgba(45, 52, 54, 0.62);
-  --color-heading: #1d2426;
+  background-color: var(--color-canvas);
+  --color-canvas: #f6f5f2;
+  --color-surface: rgba(255, 255, 255, 0.88);
+  --color-surface-strong: rgba(255, 255, 255, 0.94);
+  --color-surface-muted: rgba(255, 255, 255, 0.82);
+  --color-border: rgba(31, 37, 40, 0.08);
+  --color-border-soft: rgba(31, 37, 40, 0.06);
+  --color-border-strong: rgba(255, 255, 255, 0.36);
+  --color-text: #1f2528;
+  --color-muted: rgba(31, 37, 40, 0.72);
+  --color-muted-strong: rgba(31, 37, 40, 0.84);
+  --color-heading: #13191b;
   --color-primary: #e85d04;
   --color-primary-strong: #d9480f;
   --color-secondary: #9b59b6;
-  --color-secondary-soft: rgba(155, 89, 182, 0.18);
-  --shadow-xs: 0 20px 40px -30px rgba(32, 40, 42, 0.45);
-  --shadow-sm: 0 42px 94px -70px rgba(32, 40, 42, 0.55);
+  --color-secondary-soft: rgba(155, 89, 182, 0.2);
+  --color-chip-bg: rgba(45, 52, 54, 0.08);
+  --color-search-bg: rgba(255, 255, 255, 0.92);
+  --color-search-glow: rgba(255, 255, 255, 0.38);
+  --color-button-bg: rgba(31, 37, 40, 0.06);
+  --color-button-border: rgba(31, 37, 40, 0.1);
+  --color-eyebrow: rgba(31, 37, 40, 0.6);
+  --shadow-xs: 0 20px 40px -32px rgba(32, 40, 42, 0.45);
+  --shadow-sm: 0 42px 94px -68px rgba(32, 40, 42, 0.5);
   --radius-xl: 32px;
   --radius-lg: 24px;
   --radius-md: 20px;
   --radius-sm: 16px;
   --blur-strong: 28px;
-  background-color: var(--color-canvas);
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+  --color-canvas: #0e1216;
+  --color-surface: rgba(18, 22, 27, 0.82);
+  --color-surface-strong: rgba(18, 22, 27, 0.92);
+  --color-surface-muted: rgba(18, 22, 27, 0.78);
+  --color-border: rgba(223, 230, 233, 0.1);
+  --color-border-soft: rgba(223, 230, 233, 0.08);
+  --color-border-strong: rgba(223, 230, 233, 0.24);
+  --color-text: #f0f4f8;
+  --color-muted: rgba(223, 230, 233, 0.82);
+  --color-muted-strong: rgba(223, 230, 233, 0.9);
+  --color-heading: #ffffff;
+  --color-chip-bg: rgba(223, 230, 233, 0.12);
+  --color-search-bg: rgba(18, 22, 27, 0.9);
+  --color-search-glow: rgba(223, 230, 233, 0.16);
+  --color-button-bg: rgba(223, 230, 233, 0.08);
+  --color-button-border: rgba(223, 230, 233, 0.16);
+  --color-eyebrow: rgba(223, 230, 233, 0.62);
+  --shadow-xs: 0 30px 48px -40px rgba(8, 12, 18, 0.9);
+  --shadow-sm: 0 80px 110px -68px rgba(8, 12, 18, 0.85);
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     color-scheme: dark;
-    --color-canvas: #101419;
-    --color-surface: rgba(16, 20, 25, 0.76);
-    --color-surface-strong: rgba(16, 20, 25, 0.86);
-    --color-border: rgba(223, 230, 233, 0.08);
-    --color-text: #dfe6e9;
-    --color-muted: rgba(223, 230, 233, 0.66);
+    --color-canvas: #0e1216;
+    --color-surface: rgba(18, 22, 27, 0.82);
+    --color-surface-strong: rgba(18, 22, 27, 0.92);
+    --color-surface-muted: rgba(18, 22, 27, 0.78);
+    --color-border: rgba(223, 230, 233, 0.1);
+    --color-border-soft: rgba(223, 230, 233, 0.08);
+    --color-border-strong: rgba(223, 230, 233, 0.24);
+    --color-text: #f0f4f8;
+    --color-muted: rgba(223, 230, 233, 0.82);
+    --color-muted-strong: rgba(223, 230, 233, 0.9);
     --color-heading: #ffffff;
+    --color-chip-bg: rgba(223, 230, 233, 0.12);
+    --color-search-bg: rgba(18, 22, 27, 0.9);
+    --color-search-glow: rgba(223, 230, 233, 0.16);
+    --color-button-bg: rgba(223, 230, 233, 0.08);
+    --color-button-border: rgba(223, 230, 233, 0.16);
+    --color-eyebrow: rgba(223, 230, 233, 0.62);
     --shadow-xs: 0 30px 48px -40px rgba(8, 12, 18, 0.9);
     --shadow-sm: 0 80px 110px -68px rgba(8, 12, 18, 0.85);
   }
@@ -68,6 +111,22 @@ body::before {
   mix-blend-mode: screen;
   opacity: 0.7;
   z-index: -1;
+}
+
+:root[data-theme='dark'] body {
+  background:
+    radial-gradient(circle at 12% 18%, rgba(232, 93, 4, 0.08), transparent 55%),
+    radial-gradient(circle at 82% 18%, rgba(155, 89, 182, 0.14), transparent 42%),
+    radial-gradient(circle at 28% 78%, rgba(232, 93, 4, 0.08), transparent 48%),
+    var(--color-canvas);
+}
+
+:root[data-theme='dark'] body::before {
+  background:
+    linear-gradient(135deg, rgba(232, 93, 4, 0.08), rgba(155, 89, 182, 0.12)),
+    radial-gradient(circle at 18% 52%, rgba(255, 255, 255, 0.2), transparent 55%);
+  mix-blend-mode: lighten;
+  opacity: 0.5;
 }
 
 a {
@@ -136,7 +195,7 @@ select:focus {
   background: var(--color-surface);
   border-radius: var(--radius-lg);
   padding: clamp(1.5rem, 2vw, 2.25rem);
-  border: 1px solid rgba(255, 255, 255, 0.32);
+  border: 1px solid var(--color-border-strong);
   box-shadow: var(--shadow-xs);
   backdrop-filter: blur(var(--blur-strong));
   position: relative;
@@ -158,8 +217,8 @@ select:focus {
 }
 
 .surface-card--muted {
-  background: rgba(255, 255, 255, 0.74);
-  border: 1px solid rgba(45, 52, 54, 0.05);
+  background: var(--color-surface-muted);
+  border: 1px solid var(--color-border-soft);
 }
 
 .text-muted {
@@ -170,7 +229,7 @@ select:focus {
   font-size: 0.75rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: rgba(45, 52, 54, 0.55);
+  color: var(--color-eyebrow);
   margin: 0;
 }
 
@@ -182,12 +241,12 @@ select:focus {
   border-radius: 999px;
   padding: 0.85rem 1.6rem;
   font-weight: 600;
-  border: 1px solid transparent;
+  border: 1px solid var(--color-button-border);
   cursor: pointer;
   transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.2s ease;
   position: relative;
   overflow: hidden;
-  background: rgba(45, 52, 54, 0.04);
+  background: var(--color-button-bg);
 }
 
 .button::after {
@@ -201,7 +260,11 @@ select:focus {
 
 .button:hover {
   transform: translateY(-2px) scale(1.01);
-  box-shadow: 0 18px 40px -28px rgba(45, 52, 54, 0.35);
+  box-shadow: 0 18px 40px -28px rgba(32, 40, 42, 0.35);
+}
+
+:root[data-theme='dark'] .button:hover {
+  box-shadow: 0 18px 40px -28px rgba(8, 12, 18, 0.6);
 }
 
 .button:hover::after {
@@ -223,18 +286,19 @@ select:focus {
   background: linear-gradient(135deg, #e85d04 0%, #f48c06 100%);
   color: #fff;
   box-shadow: 0 32px 52px -32px rgba(232, 93, 4, 0.65);
+  border: none;
 }
 
 .button--secondary {
-  background: rgba(155, 89, 182, 0.14);
+  background: var(--color-secondary-soft);
   color: var(--color-secondary);
-  border-color: rgba(155, 89, 182, 0.22);
+  border-color: rgba(155, 89, 182, 0.3);
 }
 
 .button--ghost {
-  background: rgba(45, 52, 54, 0.06);
+  background: var(--color-button-bg);
   color: var(--color-text);
-  border-color: rgba(45, 52, 54, 0.08);
+  border-color: var(--color-button-border);
 }
 
 .badge {
@@ -243,44 +307,17 @@ select:focus {
   gap: 0.35rem;
   border-radius: 999px;
   padding: 0.35rem 0.9rem;
-  background: rgba(45, 52, 54, 0.05);
-  color: var(--color-muted);
+  background: var(--color-chip-bg);
+  color: var(--color-muted-strong);
   font-size: 0.8rem;
   font-weight: 500;
-}
-
-.badge--ia {
-  background: rgba(155, 89, 182, 0.18);
-  color: #4a2c6f;
-  position: relative;
-}
-
-.badge--ia::after {
-  content: '';
-  position: absolute;
-  inset: -4px;
-  border-radius: inherit;
-  border: 1px solid rgba(155, 89, 182, 0.28);
-  animation: ia-pulse 2.4s infinite;
-}
-
-@keyframes ia-pulse {
-  0%,
-  100% {
-    opacity: 0.5;
-    transform: scale(0.95);
-  }
-  50% {
-    opacity: 1;
-    transform: scale(1.05);
-  }
 }
 
 .glass-panel {
   background: var(--color-surface);
   backdrop-filter: blur(var(--blur-strong));
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(255, 255, 255, 0.24);
+  border: 1px solid var(--color-border-strong);
   box-shadow: var(--shadow-xs);
 }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,19 +6,22 @@ import App from './App';
 import { AuthProvider } from './context/AuthContext';
 import { ChatProvider } from './context/ChatContext';
 import { RecipeProvider } from './context/RecipeContext';
+import { ThemeProvider } from './context/ThemeContext';
 
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <AuthProvider>
-        <RecipeProvider>
-          <ChatProvider>
-            <App />
-          </ChatProvider>
-        </RecipeProvider>
-      </AuthProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <RecipeProvider>
+            <ChatProvider>
+              <App />
+            </ChatProvider>
+          </RecipeProvider>
+        </AuthProvider>
+      </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/RecipeDetailPage.tsx
+++ b/frontend/src/pages/RecipeDetailPage.tsx
@@ -99,8 +99,6 @@ const RecipeDetailPage = () => {
     });
   };
 
-  const isAiCreation = (activeRecipe.source?.importedFrom ?? 'manual') !== 'manual';
-
   const metadata = [
     activeRecipe.durationMinutes ? { label: 'Tempo', value: `${activeRecipe.durationMinutes} min`, icon: '⏱️' } : null,
     activeRecipe.servings ? { label: 'Porções', value: `${activeRecipe.servings}`, icon: '🍽️' } : null,
@@ -118,7 +116,6 @@ const RecipeDetailPage = () => {
         </div>
         <div className="recipe-hero__overlay" />
         <div className="recipe-hero__content">
-          {isAiCreation ? <span className="badge badge--ia">Criada com IA</span> : null}
           <h1 id="recipe-title" className="font-playfair">{activeRecipe.title}</h1>
           <p className="recipe-hero__description">{activeRecipe.description}</p>
           <div className="recipe-hero__actions">

--- a/frontend/src/pages/recipe-detail.css
+++ b/frontend/src/pages/recipe-detail.css
@@ -76,13 +76,14 @@
 }
 
 .recipe-meta__card {
-  background: rgba(255, 255, 255, 0.72);
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
   padding: 1rem 1.25rem;
   display: flex;
   align-items: center;
   gap: 1rem;
   box-shadow: var(--shadow-xs);
+  border: 1px solid var(--color-border-strong);
 }
 
 .recipe-meta__card span {
@@ -119,7 +120,8 @@
 .recipe-ingredients li {
   padding: 0.75rem 1rem;
   border-radius: var(--radius-md);
-  background: rgba(45, 52, 54, 0.04);
+  background: var(--color-chip-bg);
+  border: 1px solid var(--color-border-soft);
 }
 
 .recipe-ingredients label {


### PR DESCRIPTION
## Summary
- add a ThemeProvider and top bar toggle to switch between light and dark modes with persisted preference
- refresh global tokens, layout spacing, and component styles to improve contrast and responsiveness across viewports
- remove the IA recipe badges while updating cards and detail screens to match the new visual system

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8d22714ec8323b0ddbd0227b6aabe