### PR TITLE
Rework cooking mode navigation and dark theme

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import { useEffect } from 'react';
 
 import ChatDock from '../chat/ChatDock';
@@ -9,6 +9,9 @@ import { useRecipes } from '../../context/RecipeContext';
 
 const AppLayout = () => {
   const { loadRecipes, recipes, isLoading } = useRecipes();
+  const location = useLocation();
+  const isCookingMode =
+    location.pathname.startsWith('/app/recipes/') && location.pathname.endsWith('/cook');
 
   useEffect(() => {
     if (!recipes.length && !isLoading) {
@@ -17,19 +20,23 @@ const AppLayout = () => {
   }, [recipes.length, isLoading, loadRecipes]);
 
   return (
-    <div className="app-shell">
-      <div className="sidebar-area">
-        <Sidebar />
-      </div>
+    <div className={`app-shell${isCookingMode ? ' app-shell--cooking' : ''}`}>
+      {!isCookingMode ? (
+        <div className="sidebar-area">
+          <Sidebar />
+        </div>
+      ) : null}
       <div className="header-area">
-        <TopBar />
+        <TopBar forceCondensed={isCookingMode} />
       </div>
       <main className="main-area">
         <Outlet />
       </main>
-      <aside className="chat-area">
-        <ChatDock />
-      </aside>
+      {!isCookingMode ? (
+        <aside className="chat-area">
+          <ChatDock />
+        </aside>
+      ) : null}
     </div>
   );
 };

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -1,18 +1,41 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useAuth } from '../../context/AuthContext';
 import { useRecipes } from '../../context/RecipeContext';
 import './layout.css';
+import { useTheme } from '../../context/ThemeContext';
 
-const TopBar = () => {
+type TopBarProps = {
+  forceCondensed?: boolean;
+};
+
+const TopBar = ({ forceCondensed = false }: TopBarProps) => {
   const { user, logout } = useAuth();
   const { recipes } = useRecipes();
+  const { theme, toggleTheme } = useTheme();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const location = useLocation();
   const [query, setQuery] = useState(() => searchParams.get('q') ?? '');
-  const [isCondensed, setIsCondensed] = useState(false);
+  const [isCondensed, setIsCondensed] = useState(forceCondensed);
+  const condensedRef = useRef(isCondensed);
+
+  useEffect(() => {
+    condensedRef.current = isCondensed;
+  }, [isCondensed]);
+
+  useEffect(() => {
+    if (forceCondensed) {
+      setIsCondensed(true);
+      condensedRef.current = true;
+      return;
+    }
+
+    const shouldCondense = window.scrollY >= 32;
+    setIsCondensed(shouldCondense);
+    condensedRef.current = shouldCondense;
+  }, [forceCondensed]);
 
   const favoriteCount = useMemo(
     () => recipes.filter((recipe) => recipe.isFavorite).length,
@@ -31,14 +54,81 @@ const TopBar = () => {
   };
 
   useEffect(() => {
-    const onScroll = () => {
-      setIsCondensed(window.scrollY > 64);
+    if (forceCondensed) {
+      return;
+    }
+
+    const condenseThreshold = 32;
+    const releaseThreshold = 16;
+    const releaseHysteresis = 110;
+    const releaseCooldownMs = 250;
+
+    let ticking = false;
+    let lastScrollY = window.scrollY;
+    let lastDirection: 'up' | 'down' | 'none' = 'none';
+    let condensedAnchor = window.scrollY;
+    let releaseCooldownUntil = 0;
+
+    const applyCondensed = (next: boolean) => {
+      if (condensedRef.current === next) {
+        return;
+      }
+
+      condensedRef.current = next;
+      setIsCondensed(next);
+
+      if (next) {
+        releaseCooldownUntil = performance.now() + releaseCooldownMs;
+      }
     };
 
-    onScroll();
+    const updateCondensedState = () => {
+      const { scrollY } = window;
+      const delta = scrollY - lastScrollY;
+      const direction =
+        Math.abs(delta) <= 2
+          ? lastDirection
+          : delta > 0
+            ? 'down'
+            : 'up';
+
+      if (!condensedRef.current) {
+        if (direction === 'down' && scrollY >= condenseThreshold) {
+          condensedAnchor = scrollY;
+          applyCondensed(true);
+        }
+      } else {
+        if (direction === 'down' && scrollY > condensedAnchor) {
+          condensedAnchor = scrollY;
+        }
+
+        if (direction === 'up' && condensedAnchor - scrollY >= releaseHysteresis) {
+          condensedAnchor = scrollY;
+          applyCondensed(false);
+        } else if (scrollY <= releaseThreshold && performance.now() > releaseCooldownUntil) {
+          condensedAnchor = scrollY;
+          applyCondensed(false);
+        }
+      }
+
+      lastDirection = direction;
+      lastScrollY = scrollY;
+      ticking = false;
+    };
+
+    const onScroll = () => {
+      if (ticking) {
+        return;
+      }
+
+      ticking = true;
+      window.requestAnimationFrame(updateCondensedState);
+    };
+
+    updateCondensedState();
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
-  }, []);
+  }, [forceCondensed]);
 
   const firstName = user?.name?.split(' ')[0] ?? 'Chef';
   const timeOfDay = (() => {
@@ -64,6 +154,15 @@ const TopBar = () => {
         </div>
 
         <div className="topbar__actions">
+          <button
+            type="button"
+            onClick={toggleTheme}
+            className="button button--ghost topbar__theme-toggle"
+            aria-label={`Ativar modo ${theme === 'dark' ? 'claro' : 'escuro'}`}
+            title={theme === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro'}
+          >
+            <span aria-hidden="true">{theme === 'dark' ? '🌞' : '🌙'}</span>
+          </button>
           <button type="button" onClick={logout} className="button button--ghost topbar__logout">
             Sair
           </button>

--- a/frontend/src/components/layout/layout.css
+++ b/frontend/src/components/layout/layout.css
@@ -1,6 +1,6 @@
 .app-shell {
-  --shell-padding-y: clamp(1.5rem, 3vw, 2.75rem);
-  --shell-padding-x: clamp(1.2rem, 3vw, 3.2rem);
+  --shell-padding-y: clamp(1.15rem, 2.4vw, 2.35rem);
+  --shell-padding-x: clamp(0.75rem, 2.2vw, 1.85rem);
   display: grid;
   grid-template-columns: 260px minmax(0, 1fr) 340px;
   grid-template-rows: auto minmax(0, 1fr);
@@ -16,6 +16,23 @@
   max-width: 1600px;
 }
 
+.app-shell--cooking {
+  --shell-padding-y: clamp(0.5rem, 1.4vw, 1rem);
+  --shell-padding-x: clamp(0.6rem, 3.6vw, 1.4rem);
+  --cooking-header-height: 72px;
+  --cooking-top-gap: clamp(1rem, 3vw, 1.65rem);
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: auto 1fr;
+  grid-template-areas:
+    'header'
+    'main';
+  gap: clamp(0.75rem, 2vw, 1.2rem);
+  max-width: none;
+  padding: var(--shell-padding-y) var(--shell-padding-x);
+  margin: 0;
+  width: 100%;
+}
+
 body.chat-focus .app-shell {
   grid-template-columns: 72px minmax(0, 1fr) 1fr;
 }
@@ -28,6 +45,11 @@ body.chat-focus .app-shell {
   z-index: 10;
 }
 
+.app-shell--cooking .sidebar-area,
+.app-shell--cooking .chat-area {
+  display: none;
+}
+
 .header-area {
   grid-area: header;
   position: sticky;
@@ -35,10 +57,20 @@ body.chat-focus .app-shell {
   z-index: 30;
 }
 
+.app-shell--cooking .header-area {
+  top: 0;
+  z-index: 60;
+  min-height: var(--cooking-header-height);
+}
+
 .main-area {
   grid-area: main;
   min-height: 0;
   padding-bottom: 6rem;
+}
+
+.app-shell--cooking .main-area {
+  padding: var(--cooking-top-gap) 0 clamp(2.5rem, 6vw, 4rem);
 }
 
 .chat-area {
@@ -61,7 +93,7 @@ body.chat-focus .app-shell {
   padding: 2rem 1.75rem;
   border-radius: var(--radius-xl);
   background: var(--color-surface);
-  border: 1px solid rgba(255, 255, 255, 0.28);
+  border: 1px solid var(--color-border-strong);
   box-shadow: var(--shadow-xs);
   backdrop-filter: blur(var(--blur-strong));
   transition: width 0.35s cubic-bezier(.4,0,.2,1), min-width 0.35s cubic-bezier(.4,0,.2,1), padding 0.35s cubic-bezier(.4,0,.2,1);
@@ -112,8 +144,8 @@ body.chat-focus .app-shell {
   padding: 0.9rem 1.1rem;
   border-radius: var(--radius-md);
   font-weight: 600;
-  color: rgba(45, 52, 54, 0.6);
-  background: rgba(45, 52, 54, 0.03);
+  color: var(--color-muted);
+  background: var(--color-chip-bg);
   border: 1px solid transparent;
   transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease, border 0.25s ease;
   position: relative;
@@ -167,28 +199,36 @@ body.chat-focus .app-shell {
 
 .topbar__glass {
   width: min(100%, 880px);
-  padding: clamp(1.25rem, 2vw, 2rem) clamp(1.4rem, 3vw, 2.4rem);
+  padding: clamp(1.1rem, 2vw, 1.8rem) clamp(1.2rem, 2.8vw, 2.2rem);
   border-radius: var(--radius-xl);
   background: var(--color-surface);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid var(--color-border-strong);
   box-shadow: var(--shadow-xs);
   backdrop-filter: blur(var(--blur-strong));
   display: grid;
-  gap: 1.2rem;
+  gap: 1.1rem;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    'intro'
+    'stats'
+    'actions'
+    'search';
   transition: padding 0.3s ease, border-radius 0.3s ease, background 0.3s ease;
 }
 
 .topbar--condensed .topbar__glass {
   border-radius: 999px;
-  padding: 0.65rem 1.5rem;
-  grid-template-columns: 1fr auto;
+  padding: 0.55rem 1.2rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas: 'search actions';
   align-items: center;
-  gap: 1.1rem;
+  gap: 0.75rem;
 }
 
 .topbar__intro {
   display: grid;
   gap: 0.4rem;
+  grid-area: intro;
 }
 
 .topbar__greeting {
@@ -208,14 +248,15 @@ body.chat-focus .app-shell {
   align-items: center;
   gap: 0.6rem;
   flex-wrap: wrap;
+  grid-area: stats;
 }
 
 .topbar__badge {
-  background: rgba(45, 52, 54, 0.05);
+  background: var(--color-chip-bg);
   padding: 0.35rem 0.85rem;
   border-radius: 999px;
   font-size: 0.85rem;
-  color: var(--color-muted);
+  color: var(--color-muted-strong);
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
@@ -225,17 +266,21 @@ body.chat-focus .app-shell {
   display: flex;
   gap: 0.6rem;
   flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  grid-area: actions;
 }
 
 .topbar__search {
   display: flex;
   align-items: center;
   gap: 0.85rem;
-  background: rgba(255, 255, 255, 0.78);
-  border: 1px solid rgba(45, 52, 54, 0.06);
+  background: var(--color-search-bg);
+  border: 1px solid var(--color-border-soft);
   border-radius: 999px;
   padding: 0.55rem 0.55rem 0.55rem 1.25rem;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+  box-shadow: inset 0 0 0 1px var(--color-search-glow);
+  grid-area: search;
 }
 
 .topbar__search input {
@@ -258,15 +303,23 @@ body.chat-focus .app-shell {
   padding: 0.5rem 1.2rem;
 }
 
+.topbar__theme-toggle {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  padding: 0;
+  font-size: 1.15rem;
+  min-width: 42px;
+}
+
 .topbar--condensed .topbar__intro,
-.topbar--condensed .topbar__actions {
+.topbar--condensed .topbar__stats {
   display: none;
 }
 
 .topbar--condensed .topbar__search {
-  max-width: 360px;
-  margin-left: auto;
-  border-radius: 999px;
+  max-width: none;
+  margin: 0;
 }
 
 .topbar--condensed .topbar__greeting {
@@ -329,40 +382,32 @@ body.chat-focus .app-shell {
   .topbar__glass {
     border-radius: var(--radius-lg);
   }
-
-  .topbar--condensed .topbar__glass {
-    grid-template-columns: 1fr;
-  }
-
-  .topbar--condensed .topbar__search {
-    max-width: none;
-    margin-left: 0;
-  }
-
-  .topbar {
-    top: 0;
-  }
 }
 
 @media (max-width: 640px) {
   .app-shell {
-    padding: 1.5rem 1.1rem 5rem;
-    gap: 1.4rem;
+    padding: 1.25rem 0.85rem 5rem;
+    gap: 1.3rem;
   }
 
   .topbar__glass {
-    padding: 1.25rem 1.4rem;
-    gap: 1rem;
+    padding: 1.1rem 1.25rem;
+    gap: 0.9rem;
   }
 
   .topbar__search {
     flex-direction: column;
     align-items: stretch;
     border-radius: var(--radius-lg);
+    padding: 0.7rem;
   }
 
   .topbar__search-button,
   .topbar__logout {
     width: 100%;
+  }
+
+  .topbar__actions {
+    justify-content: flex-start;
   }
 }

--- a/frontend/src/components/recipes/RecipeCard.tsx
+++ b/frontend/src/components/recipes/RecipeCard.tsx
@@ -20,8 +20,6 @@ const RecipeCard = ({ recipe, onOpen, onToggleFavorite }: RecipeCardProps) => {
     };
   }, [recipe.coverImage]);
 
-  const isAiCreation = (recipe.source?.importedFrom ?? 'manual') !== 'manual';
-
   return (
     <article className="recipe-card">
       <div className="recipe-card__cover" style={coverStyle}>
@@ -38,7 +36,6 @@ const RecipeCard = ({ recipe, onOpen, onToggleFavorite }: RecipeCardProps) => {
             </svg>
           </span>
         </button>
-        {isAiCreation ? <span className="recipe-card__badge">✨ IA</span> : null}
       </div>
       <div className="recipe-card__content">
         <h3>{recipe.title}</h3>

--- a/frontend/src/components/recipes/recipes.css
+++ b/frontend/src/components/recipes/recipes.css
@@ -9,8 +9,8 @@
   background: var(--color-surface);
   border-radius: 28px;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.36);
-  box-shadow: 0 36px 60px -40px rgba(45, 52, 54, 0.55);
+  border: 1px solid var(--color-border-strong);
+  box-shadow: 0 36px 60px -40px rgba(32, 40, 42, 0.55);
   transition: transform 0.35s cubic-bezier(.22,1,.36,1), box-shadow 0.35s cubic-bezier(.22,1,.36,1);
   position: relative;
 }
@@ -57,9 +57,10 @@
   height: 48px;
   border: none;
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.92);
+  background: var(--color-surface-strong);
+  border: 1px solid var(--color-border-soft);
   backdrop-filter: blur(16px);
-  box-shadow: 0 22px 34px -26px rgba(45, 52, 54, 0.65);
+  box-shadow: 0 22px 34px -26px rgba(32, 40, 42, 0.55);
   cursor: pointer;
   display: grid;
   place-items: center;
@@ -83,35 +84,6 @@
 
 .recipe-card__favorite.is-favorite svg {
   fill: var(--color-primary);
-}
-
-.recipe-card__badge {
-  position: absolute;
-  bottom: 1.4rem;
-  left: 1.4rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.45rem 0.9rem;
-  border-radius: 999px;
-  background: rgba(155, 89, 182, 0.22);
-  color: #402454;
-  font-weight: 600;
-  font-size: 0.85rem;
-  box-shadow: 0 14px 22px -18px rgba(155, 89, 182, 0.75);
-  animation: ia-glow 2.8s infinite;
-}
-
-@keyframes ia-glow {
-  0%,
-  100% {
-    box-shadow: 0 18px 30px -22px rgba(155, 89, 182, 0.65);
-    transform: scale(1);
-  }
-  50% {
-    box-shadow: 0 26px 40px -20px rgba(155, 89, 182, 0.75);
-    transform: scale(1.04);
-  }
 }
 
 .recipe-card__content {
@@ -146,6 +118,8 @@
   justify-content: space-between;
   align-items: center;
   padding: 0  clamp(1.75rem, 3vw, 2.75rem) clamp(1.75rem, 3vw, 2.5rem);
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .recipe-card__cta {
@@ -166,7 +140,7 @@
   padding: 3rem 1rem;
   border: 2px dashed rgba(232, 93, 4, 0.18);
   border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.6);
+  background: var(--color-surface-muted);
 }
 
 @media (max-width: 640px) {
@@ -176,6 +150,8 @@
 
   .recipe-card__actions {
     padding: 0 clamp(1.2rem, 3vw, 2rem) clamp(1.4rem, 3vw, 2rem);
+    flex-direction: column;
+    align-items: stretch;
   }
 }
 

--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -1,0 +1,96 @@
+import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'recipe-ai-theme';
+
+interface ThemeState {
+  theme: Theme;
+  hasStoredPreference: boolean;
+}
+
+const readInitialTheme = (): ThemeState => {
+  if (typeof window === 'undefined') {
+    return { theme: 'light', hasStoredPreference: false };
+  }
+
+  const storedTheme = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+  if (storedTheme === 'light' || storedTheme === 'dark') {
+    if (typeof document !== 'undefined') {
+      document.documentElement.dataset.theme = storedTheme;
+    }
+    return { theme: storedTheme, hasStoredPreference: true };
+  }
+
+  const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+  const resolvedTheme: Theme = prefersDark ? 'dark' : 'light';
+  if (typeof document !== 'undefined') {
+    document.documentElement.dataset.theme = resolvedTheme;
+  }
+  return { theme: resolvedTheme, hasStoredPreference: false };
+};
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [state, setState] = useState<ThemeState>(() => readInitialTheme());
+
+  useEffect(() => {
+    if (state.hasStoredPreference) {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleSystemChange = (event: MediaQueryListEvent) => {
+      setState({ theme: event.matches ? 'dark' : 'light', hasStoredPreference: false });
+    };
+
+    mediaQuery.addEventListener('change', handleSystemChange);
+    return () => mediaQuery.removeEventListener('change', handleSystemChange);
+  }, [state.hasStoredPreference]);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = state.theme;
+    if (state.hasStoredPreference) {
+      window.localStorage.setItem(STORAGE_KEY, state.theme);
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [state]);
+
+  const setTheme = (nextTheme: Theme) => {
+    setState({ theme: nextTheme, hasStoredPreference: true });
+  };
+
+  const toggleTheme = () => {
+    setState((current) => ({
+      theme: current.theme === 'dark' ? 'light' : 'dark',
+      hasStoredPreference: true
+    }));
+  };
+
+  const value = useMemo(
+    () => ({
+      theme: state.theme,
+      toggleTheme,
+      setTheme
+    }),
+    [state.theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,39 +5,158 @@
   font-family: 'Manrope', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.6;
   font-weight: 400;
-  --color-canvas: #f8f7f4;
-  --color-surface: rgba(255, 255, 255, 0.82);
-  --color-surface-strong: rgba(255, 255, 255, 0.92);
-  --color-border: rgba(45, 52, 54, 0.08);
-  --color-text: #2d3436;
-  --color-muted: rgba(45, 52, 54, 0.62);
-  --color-heading: #1d2426;
+  background-color: var(--color-canvas);
+  --color-canvas: #f6f5f2;
+  --color-surface: rgba(255, 255, 255, 0.88);
+  --color-surface-strong: rgba(255, 255, 255, 0.94);
+  --color-surface-muted: rgba(255, 255, 255, 0.82);
+  --color-border: rgba(31, 37, 40, 0.08);
+  --color-border-soft: rgba(31, 37, 40, 0.06);
+  --color-border-strong: rgba(255, 255, 255, 0.36);
+  --color-text: #1f2528;
+  --color-muted: rgba(31, 37, 40, 0.72);
+  --color-muted-strong: rgba(31, 37, 40, 0.84);
+  --color-heading: #13191b;
   --color-primary: #e85d04;
   --color-primary-strong: #d9480f;
   --color-secondary: #9b59b6;
-  --color-secondary-soft: rgba(155, 89, 182, 0.18);
-  --shadow-xs: 0 20px 40px -30px rgba(32, 40, 42, 0.45);
-  --shadow-sm: 0 42px 94px -70px rgba(32, 40, 42, 0.55);
+  --color-secondary-soft: rgba(155, 89, 182, 0.2);
+  --color-chip-bg: rgba(45, 52, 54, 0.08);
+  --color-search-bg: rgba(255, 255, 255, 0.92);
+  --color-search-glow: rgba(255, 255, 255, 0.38);
+  --color-button-bg: rgba(31, 37, 40, 0.06);
+  --color-button-border: rgba(31, 37, 40, 0.1);
+  --color-eyebrow: rgba(31, 37, 40, 0.6);
+  --shadow-xs: 0 20px 40px -32px rgba(32, 40, 42, 0.45);
+  --shadow-sm: 0 42px 94px -68px rgba(32, 40, 42, 0.5);
   --radius-xl: 32px;
   --radius-lg: 24px;
   --radius-md: 20px;
   --radius-sm: 16px;
   --blur-strong: 28px;
-  background-color: var(--color-canvas);
+  --cooking-body-bg: radial-gradient(circle at 18% 16%, rgba(232, 93, 4, 0.16), transparent 62%),
+    radial-gradient(circle at 82% 10%, rgba(155, 89, 182, 0.15), transparent 58%),
+    linear-gradient(135deg, rgba(255, 240, 226, 0.92), rgba(255, 250, 244, 0.96));
+  --cooking-body-overlay: linear-gradient(135deg, rgba(232, 93, 4, 0.18), rgba(155, 89, 182, 0.18));
+  --cooking-surface: rgba(255, 253, 248, 0.94);
+  --cooking-surface-strong: rgba(255, 255, 255, 0.9);
+  --cooking-border: rgba(34, 25, 29, 0.1);
+  --cooking-text: #1f1a1b;
+  --cooking-muted: rgba(34, 25, 29, 0.68);
+  --cooking-progress-track: rgba(232, 93, 4, 0.18);
+  --cooking-progress-fill: linear-gradient(135deg, #e85d04 0%, #ffba08 100%);
+  --cooking-control-bg: rgba(34, 25, 29, 0.08);
+  --cooking-control-border: rgba(34, 25, 29, 0.14);
+  --cooking-control-hover: rgba(232, 93, 4, 0.16);
+  --cooking-control-text: #1f1a1b;
+  --cooking-voice-bg: rgba(232, 93, 4, 0.12);
+  --cooking-voice-border: rgba(232, 93, 4, 0.32);
+  --cooking-voice-active-glow: rgba(232, 93, 4, 0.28);
+  --cooking-tip-text: rgba(34, 25, 29, 0.72);
+  --cooking-ingredients-bg: rgba(255, 255, 255, 0.94);
+  --cooking-ingredients-border: rgba(232, 93, 4, 0.2);
+  --cooking-ingredients-shadow: 0 46px 90px -60px rgba(188, 99, 32, 0.35);
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+  --color-canvas: linear-gradient(
+    135deg,
+    rgba(44, 26, 62, 0.96) 0%,
+    rgba(24, 32, 48, 0.94) 55%,
+    rgba(52, 24, 40, 0.92) 100%
+  );
+  --color-surface: linear-gradient(135deg, rgba(46, 30, 68, 0.92), rgba(28, 38, 56, 0.9));
+  --color-surface-strong: linear-gradient(135deg, rgba(54, 36, 76, 0.95), rgba(32, 42, 60, 0.93));
+  --color-surface-muted: linear-gradient(135deg, rgba(40, 30, 64, 0.86), rgba(26, 34, 52, 0.84));
+  --color-border: rgba(236, 240, 247, 0.18);
+  --color-border-soft: rgba(236, 240, 247, 0.14);
+  --color-border-strong: rgba(236, 240, 247, 0.32);
+  --color-text: #f0f4f8;
+  --color-muted: rgba(226, 232, 240, 0.84);
+  --color-muted-strong: rgba(236, 240, 247, 0.9);
+  --color-heading: #ffffff;
+  --color-chip-bg: rgba(236, 240, 247, 0.16);
+  --color-search-bg: rgba(26, 32, 46, 0.85);
+  --color-search-glow: rgba(236, 240, 247, 0.22);
+  --color-button-bg: rgba(236, 240, 247, 0.12);
+  --color-button-border: rgba(236, 240, 247, 0.22);
+  --color-eyebrow: rgba(226, 232, 240, 0.7);
+  --shadow-xs: 0 30px 48px -36px rgba(18, 16, 28, 0.65);
+  --shadow-sm: 0 80px 110px -60px rgba(18, 16, 28, 0.72);
+  --cooking-body-bg: radial-gradient(circle at 18% 14%, rgba(232, 93, 4, 0.22), transparent 60%),
+    radial-gradient(circle at 78% 18%, rgba(155, 89, 182, 0.26), transparent 58%),
+    linear-gradient(145deg, rgba(46, 30, 70, 0.96), rgba(28, 36, 54, 0.94));
+  --cooking-body-overlay: linear-gradient(135deg, rgba(232, 93, 4, 0.24), rgba(155, 89, 182, 0.3));
+  --cooking-surface: linear-gradient(145deg, rgba(40, 30, 64, 0.9), rgba(26, 34, 52, 0.88));
+  --cooking-surface-strong: linear-gradient(145deg, rgba(48, 34, 70, 0.94), rgba(30, 38, 56, 0.92));
+  --cooking-border: rgba(236, 240, 247, 0.24);
+  --cooking-text: #f5f7fb;
+  --cooking-muted: rgba(236, 240, 247, 0.82);
+  --cooking-progress-track: rgba(236, 240, 247, 0.24);
+  --cooking-progress-fill: linear-gradient(135deg, #f48c06 0%, #ffba08 100%);
+  --cooking-control-bg: rgba(236, 240, 247, 0.14);
+  --cooking-control-border: rgba(236, 240, 247, 0.26);
+  --cooking-control-hover: rgba(232, 93, 4, 0.3);
+  --cooking-control-text: #f5f7fb;
+  --cooking-voice-bg: rgba(236, 240, 247, 0.18);
+  --cooking-voice-border: rgba(236, 240, 247, 0.32);
+  --cooking-voice-active-glow: rgba(232, 93, 4, 0.36);
+  --cooking-tip-text: rgba(236, 240, 247, 0.85);
+  --cooking-ingredients-bg: linear-gradient(145deg, rgba(42, 32, 68, 0.94), rgba(26, 34, 52, 0.92));
+  --cooking-ingredients-border: rgba(236, 240, 247, 0.26);
+  --cooking-ingredients-shadow: 0 60px 100px -54px rgba(20, 18, 32, 0.78);
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     color-scheme: dark;
-    --color-canvas: #101419;
-    --color-surface: rgba(16, 20, 25, 0.76);
-    --color-surface-strong: rgba(16, 20, 25, 0.86);
-    --color-border: rgba(223, 230, 233, 0.08);
-    --color-text: #dfe6e9;
-    --color-muted: rgba(223, 230, 233, 0.66);
+    --color-canvas: linear-gradient(
+      135deg,
+      rgba(44, 26, 62, 0.96) 0%,
+      rgba(24, 32, 48, 0.94) 55%,
+      rgba(52, 24, 40, 0.92) 100%
+    );
+    --color-surface: linear-gradient(135deg, rgba(46, 30, 68, 0.92), rgba(28, 38, 56, 0.9));
+    --color-surface-strong: linear-gradient(135deg, rgba(54, 36, 76, 0.95), rgba(32, 42, 60, 0.93));
+    --color-surface-muted: linear-gradient(135deg, rgba(40, 30, 64, 0.86), rgba(26, 34, 52, 0.84));
+    --color-border: rgba(236, 240, 247, 0.18);
+    --color-border-soft: rgba(236, 240, 247, 0.14);
+    --color-border-strong: rgba(236, 240, 247, 0.32);
+    --color-text: #f0f4f8;
+    --color-muted: rgba(226, 232, 240, 0.84);
+    --color-muted-strong: rgba(236, 240, 247, 0.9);
     --color-heading: #ffffff;
-    --shadow-xs: 0 30px 48px -40px rgba(8, 12, 18, 0.9);
-    --shadow-sm: 0 80px 110px -68px rgba(8, 12, 18, 0.85);
+    --color-chip-bg: rgba(236, 240, 247, 0.16);
+    --color-search-bg: rgba(26, 32, 46, 0.85);
+    --color-search-glow: rgba(236, 240, 247, 0.22);
+    --color-button-bg: rgba(236, 240, 247, 0.12);
+    --color-button-border: rgba(236, 240, 247, 0.22);
+    --color-eyebrow: rgba(226, 232, 240, 0.7);
+    --shadow-xs: 0 30px 48px -36px rgba(18, 16, 28, 0.65);
+    --shadow-sm: 0 80px 110px -60px rgba(18, 16, 28, 0.72);
+    --cooking-body-bg: radial-gradient(circle at 18% 14%, rgba(232, 93, 4, 0.22), transparent 60%),
+      radial-gradient(circle at 78% 18%, rgba(155, 89, 182, 0.26), transparent 58%),
+      linear-gradient(145deg, rgba(46, 30, 70, 0.96), rgba(28, 36, 54, 0.94));
+    --cooking-body-overlay: linear-gradient(135deg, rgba(232, 93, 4, 0.24), rgba(155, 89, 182, 0.3));
+    --cooking-surface: linear-gradient(145deg, rgba(40, 30, 64, 0.9), rgba(26, 34, 52, 0.88));
+    --cooking-surface-strong: linear-gradient(145deg, rgba(48, 34, 70, 0.94), rgba(30, 38, 56, 0.92));
+    --cooking-border: rgba(236, 240, 247, 0.24);
+    --cooking-text: #f5f7fb;
+    --cooking-muted: rgba(236, 240, 247, 0.82);
+    --cooking-progress-track: rgba(236, 240, 247, 0.24);
+    --cooking-progress-fill: linear-gradient(135deg, #f48c06 0%, #ffba08 100%);
+    --cooking-control-bg: rgba(236, 240, 247, 0.14);
+    --cooking-control-border: rgba(236, 240, 247, 0.26);
+    --cooking-control-hover: rgba(232, 93, 4, 0.3);
+    --cooking-control-text: #f5f7fb;
+    --cooking-voice-bg: rgba(236, 240, 247, 0.18);
+    --cooking-voice-border: rgba(236, 240, 247, 0.32);
+    --cooking-voice-active-glow: rgba(232, 93, 4, 0.36);
+    --cooking-tip-text: rgba(236, 240, 247, 0.85);
+    --cooking-ingredients-bg: linear-gradient(145deg, rgba(42, 32, 68, 0.94), rgba(26, 34, 52, 0.92));
+    --cooking-ingredients-border: rgba(236, 240, 247, 0.26);
+    --cooking-ingredients-shadow: 0 60px 100px -54px rgba(20, 18, 32, 0.78);
   }
 }
 
@@ -68,6 +187,33 @@ body::before {
   mix-blend-mode: screen;
   opacity: 0.7;
   z-index: -1;
+}
+
+:root[data-theme='dark'] body {
+  background:
+    radial-gradient(circle at 12% 18%, rgba(232, 93, 4, 0.14), transparent 55%),
+    radial-gradient(circle at 82% 18%, rgba(155, 89, 182, 0.2), transparent 44%),
+    linear-gradient(135deg, rgba(232, 93, 4, 0.08), rgba(155, 89, 182, 0.16)),
+    var(--color-canvas);
+}
+
+:root[data-theme='dark'] body::before {
+  background:
+    linear-gradient(135deg, rgba(232, 93, 4, 0.12), rgba(155, 89, 182, 0.18)),
+    radial-gradient(circle at 18% 52%, rgba(255, 255, 255, 0.22), transparent 55%);
+  mix-blend-mode: screen;
+  opacity: 0.6;
+}
+
+body.cooking-mode-active {
+  background: var(--cooking-body-bg);
+  color: var(--cooking-text);
+}
+
+body.cooking-mode-active::before {
+  background: var(--cooking-body-overlay);
+  mix-blend-mode: normal;
+  opacity: 0.75;
 }
 
 a {
@@ -136,7 +282,7 @@ select:focus {
   background: var(--color-surface);
   border-radius: var(--radius-lg);
   padding: clamp(1.5rem, 2vw, 2.25rem);
-  border: 1px solid rgba(255, 255, 255, 0.32);
+  border: 1px solid var(--color-border-strong);
   box-shadow: var(--shadow-xs);
   backdrop-filter: blur(var(--blur-strong));
   position: relative;
@@ -158,8 +304,8 @@ select:focus {
 }
 
 .surface-card--muted {
-  background: rgba(255, 255, 255, 0.74);
-  border: 1px solid rgba(45, 52, 54, 0.05);
+  background: var(--color-surface-muted);
+  border: 1px solid var(--color-border-soft);
 }
 
 .text-muted {
@@ -170,7 +316,7 @@ select:focus {
   font-size: 0.75rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: rgba(45, 52, 54, 0.55);
+  color: var(--color-eyebrow);
   margin: 0;
 }
 
@@ -182,12 +328,12 @@ select:focus {
   border-radius: 999px;
   padding: 0.85rem 1.6rem;
   font-weight: 600;
-  border: 1px solid transparent;
+  border: 1px solid var(--color-button-border);
   cursor: pointer;
   transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.2s ease;
   position: relative;
   overflow: hidden;
-  background: rgba(45, 52, 54, 0.04);
+  background: var(--color-button-bg);
 }
 
 .button::after {
@@ -201,7 +347,11 @@ select:focus {
 
 .button:hover {
   transform: translateY(-2px) scale(1.01);
-  box-shadow: 0 18px 40px -28px rgba(45, 52, 54, 0.35);
+  box-shadow: 0 18px 40px -28px rgba(32, 40, 42, 0.35);
+}
+
+:root[data-theme='dark'] .button:hover {
+  box-shadow: 0 18px 40px -28px rgba(8, 12, 18, 0.6);
 }
 
 .button:hover::after {
@@ -223,18 +373,19 @@ select:focus {
   background: linear-gradient(135deg, #e85d04 0%, #f48c06 100%);
   color: #fff;
   box-shadow: 0 32px 52px -32px rgba(232, 93, 4, 0.65);
+  border: none;
 }
 
 .button--secondary {
-  background: rgba(155, 89, 182, 0.14);
+  background: var(--color-secondary-soft);
   color: var(--color-secondary);
-  border-color: rgba(155, 89, 182, 0.22);
+  border-color: rgba(155, 89, 182, 0.3);
 }
 
 .button--ghost {
-  background: rgba(45, 52, 54, 0.06);
+  background: var(--color-button-bg);
   color: var(--color-text);
-  border-color: rgba(45, 52, 54, 0.08);
+  border-color: var(--color-button-border);
 }
 
 .badge {
@@ -243,44 +394,17 @@ select:focus {
   gap: 0.35rem;
   border-radius: 999px;
   padding: 0.35rem 0.9rem;
-  background: rgba(45, 52, 54, 0.05);
-  color: var(--color-muted);
+  background: var(--color-chip-bg);
+  color: var(--color-muted-strong);
   font-size: 0.8rem;
   font-weight: 500;
-}
-
-.badge--ia {
-  background: rgba(155, 89, 182, 0.18);
-  color: #4a2c6f;
-  position: relative;
-}
-
-.badge--ia::after {
-  content: '';
-  position: absolute;
-  inset: -4px;
-  border-radius: inherit;
-  border: 1px solid rgba(155, 89, 182, 0.28);
-  animation: ia-pulse 2.4s infinite;
-}
-
-@keyframes ia-pulse {
-  0%,
-  100% {
-    opacity: 0.5;
-    transform: scale(0.95);
-  }
-  50% {
-    opacity: 1;
-    transform: scale(1.05);
-  }
 }
 
 .glass-panel {
   background: var(--color-surface);
   backdrop-filter: blur(var(--blur-strong));
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(255, 255, 255, 0.24);
+  border: 1px solid var(--color-border-strong);
   box-shadow: var(--shadow-xs);
 }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,19 +6,22 @@ import App from './App';
 import { AuthProvider } from './context/AuthContext';
 import { ChatProvider } from './context/ChatContext';
 import { RecipeProvider } from './context/RecipeContext';
+import { ThemeProvider } from './context/ThemeContext';
 
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <AuthProvider>
-        <RecipeProvider>
-          <ChatProvider>
-            <App />
-          </ChatProvider>
-        </RecipeProvider>
-      </AuthProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <RecipeProvider>
+            <ChatProvider>
+              <App />
+            </ChatProvider>
+          </RecipeProvider>
+        </AuthProvider>
+      </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/CookingModePage.tsx
+++ b/frontend/src/pages/CookingModePage.tsx
@@ -303,21 +303,47 @@ const CookingModePage = () => {
             Passo {currentStepIndex + 1} de {steps.length}
           </small>
         </div>
-        <button
-          type="button"
-          className={`cooking-mode__voice${isListening ? ' is-active' : ''}`}
-          onClick={toggleVoiceCommands}
-          disabled={!isVoiceSupported}
-        >
-          {isVoiceSupported ? (isListening ? '🎙️' : '🎤') : '🚫'}
-        </button>
+        <div className="cooking-mode__actions">
+          <button type="button" className="cooking-mode__ingredients" onClick={revealIngredients}>
+            Ver ingredientes
+          </button>
+          <button
+            type="button"
+            className={`cooking-mode__voice${isListening ? ' is-active' : ''}`}
+            onClick={toggleVoiceCommands}
+            disabled={!isVoiceSupported}
+            aria-pressed={isListening}
+          >
+            {isVoiceSupported ? (isListening ? '🎙️' : '🎤') : '🚫'}
+          </button>
+        </div>
       </header>
 
-      <main className="cooking-mode__stage">
-        <p className="cooking-mode__step-label">Passo {currentStep.order}</p>
-        <div className="cooking-mode__step-text">{renderStepDescription(currentStep.description)}</div>
-        {currentStep.tips ? <p className="cooking-mode__tip">💡 {currentStep.tips}</p> : null}
-      </main>
+      <div className="cooking-mode__stage-shell">
+        <button
+          type="button"
+          className="cooking-mode__nav-arrow cooking-mode__nav-arrow--prev"
+          onClick={previousStep}
+          disabled={currentStepIndex === 0}
+          aria-label="Passo anterior"
+        >
+          ‹
+        </button>
+        <main className="cooking-mode__stage">
+          <p className="cooking-mode__step-label">Passo {currentStep.order}</p>
+          <div className="cooking-mode__step-text">{renderStepDescription(currentStep.description)}</div>
+          {currentStep.tips ? <p className="cooking-mode__tip">💡 {currentStep.tips}</p> : null}
+        </main>
+        <button
+          type="button"
+          className="cooking-mode__nav-arrow cooking-mode__nav-arrow--next"
+          onClick={nextStep}
+          disabled={currentStepIndex === steps.length - 1}
+          aria-label="Próximo passo"
+        >
+          ›
+        </button>
+      </div>
 
       <footer className="cooking-mode__footer">
         <div className="cooking-mode__status">{voiceStatus}</div>
@@ -330,22 +356,6 @@ const CookingModePage = () => {
             </button>
           </div>
         ) : null}
-        <div className="cooking-mode__nav">
-          <button type="button" className="button button--ghost" onClick={previousStep} disabled={currentStepIndex === 0}>
-            Passo anterior
-          </button>
-          <button
-            type="button"
-            className="button button--primary"
-            onClick={nextStep}
-            disabled={currentStepIndex === steps.length - 1}
-          >
-            Próximo passo
-          </button>
-        </div>
-        <button type="button" className="cooking-mode__ingredients" onClick={revealIngredients}>
-          Ver ingredientes
-        </button>
       </footer>
 
       <aside className={`cooking-mode__ingredients-panel${showIngredients ? ' is-visible' : ''}`}>

--- a/frontend/src/pages/RecipeDetailPage.tsx
+++ b/frontend/src/pages/RecipeDetailPage.tsx
@@ -99,8 +99,6 @@ const RecipeDetailPage = () => {
     });
   };
 
-  const isAiCreation = (activeRecipe.source?.importedFrom ?? 'manual') !== 'manual';
-
   const metadata = [
     activeRecipe.durationMinutes ? { label: 'Tempo', value: `${activeRecipe.durationMinutes} min`, icon: '⏱️' } : null,
     activeRecipe.servings ? { label: 'Porções', value: `${activeRecipe.servings}`, icon: '🍽️' } : null,
@@ -118,7 +116,6 @@ const RecipeDetailPage = () => {
         </div>
         <div className="recipe-hero__overlay" />
         <div className="recipe-hero__content">
-          {isAiCreation ? <span className="badge badge--ia">Criada com IA</span> : null}
           <h1 id="recipe-title" className="font-playfair">{activeRecipe.title}</h1>
           <p className="recipe-hero__description">{activeRecipe.description}</p>
           <div className="recipe-hero__actions">

--- a/frontend/src/pages/cooking-mode.css
+++ b/frontend/src/pages/cooking-mode.css
@@ -1,49 +1,80 @@
-body.cooking-mode-active {
-  background: #101419;
-  color: #dfe6e9;
-}
-
 .cooking-mode {
-  position: fixed;
-  inset: 0;
-  background: radial-gradient(circle at 20% 20%, rgba(155, 89, 182, 0.3), transparent 65%),
-    radial-gradient(circle at 80% 15%, rgba(232, 93, 4, 0.35), transparent 60%),
-    #101419;
-  color: #fff;
+  position: relative;
+  width: min(1180px, 100%);
+  margin: 0 auto;
+  min-height: calc(100vh - var(--cooking-header-height, 72px) - var(--cooking-top-gap, 24px));
+  min-height: calc(100dvh - var(--cooking-header-height, 72px) - var(--cooking-top-gap, 24px));
+  background: linear-gradient(145deg, var(--cooking-surface), var(--cooking-surface-strong));
+  color: var(--cooking-text);
   display: grid;
-  grid-template-rows: auto 1fr auto;
-  padding: clamp(1.5rem, 3vw, 2.5rem);
-  gap: clamp(1.5rem, 3vw, 2.5rem);
-  font-family: 'Manrope', sans-serif;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  padding: clamp(1.6rem, 3.6vw, 2.8rem) clamp(1.2rem, 4vw, 2.8rem);
+  gap: clamp(1.5rem, 3vw, 2.6rem);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--cooking-border);
+  box-shadow: 0 48px 96px -68px rgba(18, 22, 27, 0.4);
+  backdrop-filter: blur(26px);
+  transition: background 0.35s ease, color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
 }
 
 .cooking-mode__top {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: clamp(0.75rem, 2vw, 1.2rem);
+  color: inherit;
+  flex-wrap: wrap;
 }
 
 .cooking-mode__back {
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  color: #fff;
-  padding: 0.6rem 1.1rem;
+  background: var(--cooking-control-bg);
+  border: 1px solid var(--cooking-control-border);
+  color: var(--cooking-control-text);
+  padding: 0.65rem 1.2rem;
   border-radius: 999px;
   cursor: pointer;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cooking-mode__back:hover {
+  background: var(--cooking-control-hover);
+  border-color: var(--color-primary);
 }
 
 .cooking-mode__info {
   flex: 1;
+  min-width: clamp(260px, 45vw, 420px);
   text-align: center;
   display: grid;
-  gap: 0.35rem;
+  gap: 0.45rem;
+  color: inherit;
+}
+
+.cooking-mode__info .font-playfair {
+  font-size: clamp(1.3rem, 3vw, 2.2rem);
+  line-height: 1.25;
+}
+
+.cooking-mode__info small {
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  color: var(--cooking-muted);
+}
+
+.cooking-mode__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
 }
 
 .cooking-mode__progress {
   width: 100%;
-  height: 6px;
-  background: rgba(255, 255, 255, 0.16);
+  height: 7px;
+  background: var(--cooking-progress-track);
   border-radius: 999px;
   overflow: hidden;
 }
@@ -51,29 +82,45 @@ body.cooking-mode-active {
 .cooking-mode__progress div {
   width: 100%;
   height: 100%;
-  background: linear-gradient(135deg, #e85d04, #ffba08);
+  background: var(--cooking-progress-fill);
   transform-origin: left;
-  transition: transform 0.3s ease;
+  transition: transform 0.3s ease, background 0.3s ease;
 }
 
 .cooking-mode__voice {
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: var(--cooking-voice-bg);
+  border: 1px solid var(--cooking-voice-border);
+  color: var(--cooking-control-text);
   font-size: 1.4rem;
   cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+}
+
+.cooking-mode__voice:hover {
+  background: var(--cooking-control-hover);
 }
 
 .cooking-mode__voice.is-active {
-  background: rgba(232, 93, 4, 0.25);
-  box-shadow: 0 0 0 4px rgba(232, 93, 4, 0.25);
+  background: linear-gradient(135deg, var(--color-primary), #ffba08);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 0 0 4px var(--cooking-voice-active-glow);
 }
 
 .cooking-mode__voice:disabled {
-  opacity: 0.4;
+  opacity: 0.45;
   cursor: not-allowed;
+  box-shadow: none;
+}
+
+.cooking-mode__stage-shell {
+  position: relative;
+  display: grid;
 }
 
 .cooking-mode__stage {
@@ -81,34 +128,45 @@ body.cooking-mode-active {
   gap: 1.5rem;
   align-content: center;
   text-align: center;
+  color: inherit;
+  padding: 0 clamp(3rem, 9vw, 4.75rem);
 }
 
 .cooking-mode__step-label {
   margin: 0;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--cooking-muted);
 }
 
 .cooking-mode__step-text {
   font-family: 'Playfair Display', serif;
-  font-size: clamp(2.2rem, 6vw, 3.6rem);
+  font-size: clamp(2rem, 5.5vw, 3.2rem);
   line-height: 1.25;
+  color: var(--cooking-text);
 }
 
 .cooking-mode__tip {
   margin: 0;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--cooking-tip-text);
+  font-size: clamp(1.05rem, 2.8vw, 1.3rem);
+  font-weight: 600;
 }
 
 .cooking-mode__timer-button {
-  background: rgba(232, 93, 4, 0.25);
+  background: linear-gradient(135deg, var(--color-primary), #ffba08);
   border: none;
   color: #fff;
-  padding: 0.15rem 0.65rem;
+  padding: 0.2rem 0.75rem;
   border-radius: 12px;
   cursor: pointer;
   font-size: inherit;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.cooking-mode__timer-button:hover {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
 }
 
 .cooking-mode__footer {
@@ -119,57 +177,118 @@ body.cooking-mode-active {
 .cooking-mode__status {
   min-height: 24px;
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--cooking-muted);
 }
 
 .cooking-mode__timer {
   display: inline-flex;
   align-items: center;
   gap: 1rem;
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--cooking-surface-strong);
   padding: 0.75rem 1.2rem;
   border-radius: 18px;
+  border: 1px solid var(--cooking-border);
+  box-shadow: 0 32px 68px -56px rgba(18, 22, 27, 0.38);
+  transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.cooking-mode__timer strong {
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
 }
 
 .cooking-mode__timer button {
   background: none;
   border: none;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--cooking-control-text);
   cursor: pointer;
+  font-weight: 600;
+  transition: color 0.2s ease;
 }
 
-.cooking-mode__nav {
-  display: flex;
-  justify-content: center;
-  gap: 1rem;
+.cooking-mode__timer button:hover {
+  color: var(--color-primary);
 }
 
 .cooking-mode__ingredients {
   justify-self: center;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  color: #fff;
-  padding: 0.5rem 1.2rem;
+  background: var(--cooking-control-bg);
+  border: 1px solid var(--cooking-control-border);
+  color: var(--cooking-control-text);
+  padding: 0.55rem 1.3rem;
   border-radius: 999px;
   cursor: pointer;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.cooking-mode__ingredients:hover {
+  background: var(--cooking-control-hover);
+  border-color: var(--color-primary);
+}
+
+.cooking-mode__nav-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: clamp(44px, 6vw, 58px);
+  height: clamp(44px, 6vw, 58px);
+  border-radius: 999px;
+  border: 1px solid var(--cooking-control-border);
+  background: var(--cooking-control-bg);
+  color: var(--cooking-control-text);
+  font-size: clamp(1.6rem, 4vw, 2rem);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  z-index: 2;
+}
+
+.cooking-mode__nav-arrow:hover {
+  background: var(--cooking-control-hover);
+  border-color: var(--color-primary);
+  transform: translateY(-50%) scale(1.05);
+}
+
+.cooking-mode__nav-arrow:active {
+  transform: translateY(-50%) scale(0.97);
+}
+
+.cooking-mode__nav-arrow:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: translateY(-50%);
+}
+
+.cooking-mode__nav-arrow--prev {
+  left: clamp(0.5rem, 3vw, 1.8rem);
+}
+
+.cooking-mode__nav-arrow--next {
+  right: clamp(0.5rem, 3vw, 1.8rem);
 }
 
 .cooking-mode__ingredients-panel {
   position: fixed;
-  top: clamp(1.5rem, 3vw, 2.5rem);
+  top: calc(var(--cooking-header-height, 72px) + clamp(1rem, 3vw, 1.6rem));
   right: clamp(1.5rem, 3vw, 2.5rem);
   width: min(320px, 70vw);
-  max-height: 70vh;
+  max-height: min(70vh, 70dvh);
   overflow-y: auto;
-  background: rgba(16, 20, 25, 0.85);
-  backdrop-filter: blur(18px);
+  background: var(--cooking-ingredients-bg);
+  backdrop-filter: blur(24px);
   border-radius: 24px;
   padding: 1.5rem;
-  box-shadow: 0 40px 80px -50px rgba(0, 0, 0, 0.65);
+  border: 1px solid var(--cooking-ingredients-border);
+  box-shadow: var(--cooking-ingredients-shadow);
   opacity: 0;
   transform: translateY(-16px);
   pointer-events: none;
   transition: opacity 0.3s ease, transform 0.3s ease;
+  color: var(--cooking-text);
+  z-index: 80;
 }
 
 .cooking-mode__ingredients-panel.is-visible {
@@ -181,6 +300,7 @@ body.cooking-mode-active {
 .cooking-mode__ingredients-panel h2 {
   margin-top: 0;
   font-family: 'Playfair Display', serif;
+  color: var(--color-heading);
 }
 
 .cooking-mode__ingredients-panel ul {
@@ -193,25 +313,38 @@ body.cooking-mode-active {
 
 .cooking-mode__ingredients-panel li {
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--cooking-muted);
 }
 
 .cooking-mode__ingredients-panel strong {
-  color: #ffba08;
+  color: var(--color-primary);
 }
 
 .cooking-mode__ingredients-panel em {
   font-style: normal;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--cooking-muted);
+}
+
+@media (max-width: 1024px) {
+  .cooking-mode {
+    width: min(100%, 960px);
+  }
 }
 
 @media (max-width: 768px) {
   .cooking-mode {
-    padding: 1.5rem;
+    border-radius: var(--radius-lg);
+    padding: clamp(1.2rem, 5vw, 1.8rem);
+  }
+
+  .cooking-mode__actions {
+    width: 100%;
+    justify-content: center;
   }
 
   .cooking-mode__stage {
-    gap: 1rem;
+    padding: 0 clamp(2.5rem, 12vw, 3.6rem);
+    gap: 1.2rem;
   }
 
   .cooking-mode__step-text {
@@ -231,16 +364,31 @@ body.cooking-mode-active {
 }
 
 @media (max-width: 480px) {
-  .cooking-mode__top {
-    flex-wrap: wrap;
-  }
-
-  .cooking-mode__nav {
-    flex-direction: column;
-  }
-
   .cooking-mode__voice {
     width: 40px;
     height: 40px;
+  }
+
+  .cooking-mode__nav-arrow {
+    width: 38px;
+    height: 38px;
+    font-size: 1.4rem;
+  }
+
+  .cooking-mode__nav-arrow--prev {
+    left: clamp(0.35rem, 5vw, 1rem);
+  }
+
+  .cooking-mode__nav-arrow--next {
+    right: clamp(0.35rem, 5vw, 1rem);
+  }
+
+  .cooking-mode__stage {
+    padding: 0 clamp(2rem, 14vw, 2.8rem);
+  }
+
+  .cooking-mode__ingredients {
+    width: 100%;
+    text-align: center;
   }
 }

--- a/frontend/src/pages/import.css
+++ b/frontend/src/pages/import.css
@@ -26,7 +26,7 @@
     radial-gradient(circle at 15% 20%, rgba(155, 89, 182, 0.45), transparent 55%),
     radial-gradient(circle at 75% 10%, rgba(232, 93, 4, 0.4), transparent 60%),
     linear-gradient(135deg, rgba(16, 20, 25, 0.08), transparent);
-  animation: aurora 12s ease-in-out infinite alternate;
+  animation: none;
 }
 
 .import-hero__card {

--- a/frontend/src/pages/recipe-detail.css
+++ b/frontend/src/pages/recipe-detail.css
@@ -76,13 +76,14 @@
 }
 
 .recipe-meta__card {
-  background: rgba(255, 255, 255, 0.72);
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
   padding: 1rem 1.25rem;
   display: flex;
   align-items: center;
   gap: 1rem;
   box-shadow: var(--shadow-xs);
+  border: 1px solid var(--color-border-strong);
 }
 
 .recipe-meta__card span {
@@ -119,7 +120,8 @@
 .recipe-ingredients li {
   padding: 0.75rem 1rem;
   border-radius: var(--radius-md);
-  background: rgba(45, 52, 54, 0.04);
+  background: var(--color-chip-bg);
+  border: 1px solid var(--color-border-soft);
 }
 
 .recipe-ingredients label {


### PR DESCRIPTION
## Summary
- reposition the cooking mode controls with lateral step arrows, a relocated ingredients shortcut, and refined header/tip typography for better readability
- update cooking mode styles and responsive rules to keep the stage clear on smaller screens while enlarging key text and button targets
- soften the dark theme palette with the import hero gradient cues and freeze the import aurora backdrop to stay static

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8d22714ec8323b0ddbd0227b6aabe