### PR TITLE
Fix Supabase chat persistence compatibility

### DIFF
--- a/src/app/routers/chat.py
+++ b/src/app/routers/chat.py
@@ -11,8 +11,11 @@ router = APIRouter(prefix="/chat", tags=["chat"])
 
 
 @router.get("/history", response_model=list[ChatMessage])
-async def get_history(user: CurrentUser = Depends(get_current_user)) -> list[ChatMessage]:
-    return [ChatMessage(**msg) for msg in chat_store.list_messages(str(user.id))]
+async def get_history(
+    user: CurrentUser = Depends(get_current_user),
+    supa: Client = Depends(get_supabase),
+) -> list[ChatMessage]:
+    return [ChatMessage(**msg) for msg in chat_store.list_messages(str(user.id), supa)]
 
 
 

--- a/src/services/chat_store.py
+++ b/src/services/chat_store.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 from datetime import datetime, timezone
-import uuid
+from uuid import uuid4
 
 from src.services.chat_agent import run_chat_agent
 from supabase import Client
@@ -10,11 +10,16 @@ from src.services.embedding import embedding_query
 from src.services import persist_supabase
 
 
+MAX_CONTEXT_CHARS = 4000
+MAX_HISTORY_MESSAGES = 50
+
+
 def send_message(
     user: CurrentUser,
     supa: Client,
     message: str,
     recipe_id: Optional[str] = None,
+    client_message_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Orquestra o processo de resposta do chat:
@@ -27,65 +32,125 @@ def send_message(
     user_id = str(user.id)
 
     # 1. Salva a mensagem do usuário no banco de dados
-    persist_supabase.save_chat_message(user_id, "user", message, recipe_id, supa)
+    persist_supabase.save_chat_message(
+        user_id,
+        "user",
+        message,
+        supa,
+        recipe_id=recipe_id,
+        client_message_id=client_message_id,
+    )
 
     # 2. Busca o contexto relevante (da receita específica ou por similaridade)
-    context_payload = type('obj', (object,), {'recipeId': recipe_id, 'message': message})
-    context = get_context(context_payload, user, supa)
+    context_text, context_recipe_ids = get_context(
+        message=message,
+        recipe_id=recipe_id,
+        user=user,
+        supa=supa,
+    )
 
     # 3. Busca o histórico completo do banco de dados para dar memória à IA
-    full_history = persist_supabase.get_chat_history(user_id, supa)
-    history_payload = [{"role": item["role"], "content": item["content"]} for item in full_history]
-    
+    full_history = persist_supabase.get_chat_history(
+        user_id,
+        supa,
+        limit=MAX_HISTORY_MESSAGES,
+    )
+    history_payload = _build_history_payload(full_history)
+
+    if history_payload:
+        last_entry = history_payload[-1]
+        if last_entry.get("role") == "user" and last_entry.get("content") == message:
+            history_payload = history_payload[:-1]
+
     # 4. Chama o agente com o histórico correto e o contexto
-    assistant_text = run_chat_agent(history_payload, message, context)
+    assistant_text = run_chat_agent(history_payload, message, context_text)
 
     # 5. Salva a resposta do assistente no banco de dados
-    assistant_entry = persist_supabase.save_chat_message(user_id, "assistant", assistant_text, None, supa)
+    assistant_record = persist_supabase.save_chat_message(
+        user_id,
+        "assistant",
+        assistant_text,
+        supa,
+        related_recipe_ids=context_recipe_ids or None,
+    )
 
-    return assistant_entry
+    return _format_chat_message(assistant_record)
 
 
-def get_context(user_payload, user: CurrentUser, supa: Client) -> Optional[str]:
+def list_messages(user_id: str, supa: Client, limit: int = 50) -> List[Dict[str, Any]]:
+    """Retorna o histórico do chat no formato esperado pela API."""
+    records = persist_supabase.get_chat_history(user_id, supa, limit=limit)
+    return [_format_chat_message(record) for record in records]
+
+
+def get_context(
+    message: str,
+    recipe_id: Optional[str],
+    user: CurrentUser,
+    supa: Client,
+) -> tuple[Optional[str], List[str]]:
     """Busca o contexto relevante para uma pergunta, seja de uma receita específica ou por similaridade."""
     user_id = str(user.id)
 
     # Cenário 1: O usuário está vendo uma receita específica
-    if user_payload.recipeId:
-        try:
-            # Busca o chunk da receita, garantindo que pertence ao usuário
-            chunk_result = persist_supabase.get_chunk_by_id(user_payload.recipeId, user_id, supa)
-            if chunk_result and chunk_result.data:
-                full_chunk_text = chunk_result.data[0].get('chunk_text', '')
-                return compress_chunk_text(full_chunk_text)
-            return None
-        except Exception as e:
-            print(f"Erro ao buscar chunk pelo ID {user_payload.recipeId}: {e}")
-            return None
+    if recipe_id:
+        chunks = persist_supabase.get_recipe_chunks(supa, recipe_id)
+        if not chunks:
+            return None, [str(recipe_id)]
+
+        context_parts: List[str] = []
+        for chunk in chunks:
+            compressed = compress_chunk_text(chunk.get("chunk_text", ""))
+            if compressed:
+                context_parts.append(compressed)
+
+        context_text = _truncate_context("\n\n".join(context_parts).strip())
+        return (context_text or None, [str(recipe_id)])
 
     # Cenário 2: O usuário faz uma pergunta genérica
-    else:
-        message_embeded = embedding_query(user_payload.message)
-        similar_chunks = persist_supabase.find_similar_chunks(
-            supa,
-            user_id,
-            message_embeded,
-        )
+    try:
+        message_embeded = embedding_query(message)
+    except Exception as exc:
+        print(f"Erro ao gerar embedding da mensagem: {exc}")
+        return None, []
+    similar_chunks = persist_supabase.find_similar_chunks(
+        supa,
+        user_id,
+        message_embeded,
+    )
 
-        if not similar_chunks:
-            return None
+    if not similar_chunks:
+        return None, []
 
-        context_parts = ["Com base nas suas receitas, aqui estão algumas informações que podem ser úteis:"]
-        for chunk in similar_chunks:
-            full_chunk_text = chunk.get('chunk_text', '')
-            compressed_text = compress_chunk_text(full_chunk_text)
-            if compressed_text:
-                context_parts.append(f"\n--- Trecho de Receita ---\n{compressed_text}")
+    context_parts = [
+        "Com base nas suas receitas, aqui estão algumas informações que podem ser úteis:",
+    ]
+    related_recipe_ids: List[str] = []
 
-        if len(context_parts) > 1:
-            return "\n".join(context_parts)
+    for chunk in similar_chunks:
+        recipe_id_value = chunk.get("recipe_id")
+        if recipe_id_value:
+            recipe_id_str = str(recipe_id_value)
+            if recipe_id_str not in related_recipe_ids:
+                related_recipe_ids.append(recipe_id_str)
 
-        return None
+        full_chunk_text = chunk.get("chunk_text", "")
+        compressed_text = compress_chunk_text(full_chunk_text)
+        if compressed_text:
+            context_parts.append(f"\n--- Trecho de Receita ---\n{compressed_text}")
+
+    if len(context_parts) > 1:
+        return _truncate_context("\n".join(context_parts)), related_recipe_ids
+
+    return None, related_recipe_ids
+
+
+def _truncate_context(context: str) -> str:
+    if not context:
+        return ""
+    if len(context) <= MAX_CONTEXT_CHARS:
+        return context
+    return context[:MAX_CONTEXT_CHARS].rstrip() + "..."
         
         
 def compress_chunk_text(full_text: str) -> str:
@@ -116,5 +181,77 @@ def compress_chunk_text(full_text: str) -> str:
             compressed_parts.append(f"## {section.strip()}")
                 
     # Junta as seções importantes com um espaçamento melhor para a IA
-    return "\n\n".join(compressed_parts)
+    condensed_text = "\n\n".join(compressed_parts).strip()
+
+    if not condensed_text:
+        condensed_text = full_text.strip()
+
+    max_length = 1500
+    if len(condensed_text) > max_length:
+        condensed_text = condensed_text[:max_length].rstrip() + "..."
+
+    return condensed_text
+
+
+def _build_history_payload(records: Sequence[Dict[str, Any]]) -> List[Dict[str, str]]:
+    history: List[Dict[str, str]] = []
+    for item in records:
+        role = item.get("role")
+        content = item.get("content")
+        if not role or not content:
+            continue
+        history.append({"role": role, "content": content})
+    return history
+
+
+def _format_chat_message(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Normaliza o formato da mensagem para o contrato da API."""
+    if not record:
+        return {
+            "id": str(uuid4()),
+            "role": "assistant",
+            "content": "",
+            "createdAt": datetime.now(timezone.utc).isoformat(),
+        }
+
+    message_id = (
+        record.get("message_id")
+        or record.get("id")
+        or record.get("uuid")
+        or str(uuid4())
+    )
+
+    created_at = record.get("created_at")
+    if isinstance(created_at, datetime):
+        created_at_iso = created_at.astimezone(timezone.utc).isoformat()
+    elif isinstance(created_at, str) and created_at:
+        try:
+            created_at_iso = datetime.fromisoformat(created_at.replace("Z", "+00:00")).astimezone(timezone.utc).isoformat()
+        except ValueError:
+            created_at_iso = created_at
+    else:
+        created_at_iso = datetime.now(timezone.utc).isoformat()
+
+    related_recipe_ids = record.get("related_recipe_ids")
+    if isinstance(related_recipe_ids, str):
+        related_recipe_ids = [related_recipe_ids]
+    elif isinstance(related_recipe_ids, list):
+        related_recipe_ids = [str(value) for value in related_recipe_ids if value]
+        if not related_recipe_ids:
+            related_recipe_ids = None
+    else:
+        related_recipe_ids = None
+
+    suggestions = record.get("suggestions")
+    if suggestions is not None and not isinstance(suggestions, list):
+        suggestions = None
+
+    return {
+        "id": str(message_id),
+        "role": record.get("role", "assistant"),
+        "content": record.get("content", ""),
+        "createdAt": created_at_iso,
+        "relatedRecipeIds": related_recipe_ids,
+        "suggestions": suggestions,
+    }
 


### PR DESCRIPTION
## Summary
- add a backwards-compatible fallback when calling the `match_recipe_chunks` RPC so RAG keeps working even if the SQL function lacks the owner filter argument
- adjust chat message persistence to handle Supabase Python client versions without `.select()` on inserts and fetch the stored record reliably

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d95db5670c8323aa1ea20283ed294d