### PR TITLE
Refine mobile timeline layout and navigation

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 
 import ChatDock from '../chat/ChatDock';
 import './layout.css';
-import Sidebar from './Sidebar';
 import TopBar from './TopBar';
 import BottomNav from './BottomNav';
 import { useRecipes } from '../../context/RecipeContext';
@@ -23,11 +22,6 @@ const AppLayout = () => {
   return (
     <>
       <div className={`app-shell${isCookingMode ? ' app-shell--cooking' : ''}`}>
-        {!isCookingMode ? (
-          <div className="sidebar-area">
-            <Sidebar />
-          </div>
-        ) : null}
         <div className="header-area">
           <TopBar forceCondensed={isCookingMode} />
         </div>

--- a/frontend/src/components/layout/BottomNav.tsx
+++ b/frontend/src/components/layout/BottomNav.tsx
@@ -95,31 +95,25 @@ const BottomNav = () => {
       label: 'Importar',
       icon: (
         <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path
-            d="M12 3v12"
+          <circle
+            cx="12"
+            cy="12"
+            r="9"
             fill="none"
             stroke="currentColor"
-            strokeWidth="1.7"
-            strokeLinecap="round"
-            strokeLinejoin="round"
+            strokeWidth="1.8"
           />
           <path
-            d="M16 8.5 12 4.5 8 8.5"
-            fill="none"
+            d="M12 8v8"
             stroke="currentColor"
-            strokeWidth="1.7"
+            strokeWidth="1.8"
             strokeLinecap="round"
-            strokeLinejoin="round"
           />
-          <rect
-            x="4.5"
-            y="13.75"
-            width="15"
-            height="6.75"
-            rx="2"
-            fill="none"
+          <path
+            d="M8 12h8"
             stroke="currentColor"
-            strokeWidth="1.7"
+            strokeWidth="1.8"
+            strokeLinecap="round"
           />
         </svg>
       ),
@@ -182,18 +176,24 @@ const BottomNav = () => {
   return (
     <nav className="bottom-nav" aria-label="Navegação principal">
       <div className="bottom-nav__inner">
-        {navItems.map((item) => (
-          <Link
-            key={item.key}
-            to={item.to}
-            className={`bottom-nav__item${item.isActive ? ' bottom-nav__item--active' : ''}`}
-          >
-            <span className="bottom-nav__icon" aria-hidden="true">
-              {item.icon}
-            </span>
-            <span className="bottom-nav__label">{item.label}</span>
-          </Link>
-        ))}
+        {navItems.map((item) => {
+          const itemClasses = ['bottom-nav__item'];
+          if (item.key === 'import') {
+            itemClasses.push('bottom-nav__item--import');
+          }
+          if (item.isActive) {
+            itemClasses.push('bottom-nav__item--active');
+          }
+
+          return (
+            <Link key={item.key} to={item.to} className={itemClasses.join(' ')}>
+              <span className="bottom-nav__icon" aria-hidden="true">
+                {item.icon}
+              </span>
+              <span className="bottom-nav__label">{item.label}</span>
+            </Link>
+          );
+        })}
       </div>
     </nav>
   );

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -1,30 +1,17 @@
-import { FormEvent, useMemo, useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
-import { useAuth } from '../../context/AuthContext';
-import { useRecipes } from '../../context/RecipeContext';
 import './layout.css';
-import { useTheme } from '../../context/ThemeContext';
 
 type TopBarProps = {
   forceCondensed?: boolean;
 };
 
 const TopBar = ({ forceCondensed }: TopBarProps) => {
-  const { user } = useAuth();
-  const { recipes } = useRecipes();
-  const { theme, toggleTheme } = useTheme();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const location = useLocation();
   const [query, setQuery] = useState(() => searchParams.get('q') ?? '');
-
-  const view = searchParams.get('view');
-
-  const favoriteCount = useMemo(
-    () => recipes.filter((recipe) => recipe.isFavorite).length,
-    [recipes]
-  );
 
   const handleSearch = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -36,68 +23,43 @@ const TopBar = ({ forceCondensed }: TopBarProps) => {
     }
     navigate({ pathname: location.pathname, search: params.toString() });
   };
-
-
-  const firstName = user?.name?.split(' ')[0] ?? 'Chef';
-  const timeOfDay = (() => {
-    const hour = new Date().getHours();
-    if (hour < 12) return 'Bom dia';
-    if (hour < 18) return 'Boa tarde';
-    return 'Boa noite';
-  })();
-
   const topbarClassName = `topbar${forceCondensed ? ' topbar--condensed' : ''}`;
 
   return (
     <header className={topbarClassName}>
-      <div className="topbar__glass">
-        <div className="topbar__header">
-          <div className="topbar__titles">
-            <span className="topbar__eyebrow">{timeOfDay}, {firstName}</span>
-            <h1 className="topbar__title">Timeline das suas receitas</h1>
-            <p className="topbar__subtitle">
-              Uma jornada cronológica para sua culinária autoral ganhar novas releituras e inspirações.
-            </p>
-          </div>
-          <div className="topbar__actions">
-            <button
-              type="button"
-              onClick={toggleTheme}
-              className="button button--ghost topbar__theme-toggle"
-              aria-label={`Ativar modo ${theme === 'dark' ? 'claro' : 'escuro'}`}
-              title={theme === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro'}
-            >
-              <span aria-hidden="true">{theme === 'dark' ? '🌞' : '🌙'}</span>
-            </button>
-          </div>
-        </div>
-
-        <div className="topbar__search-card">
-          <form onSubmit={handleSearch} className="topbar__search" role="search">
-            <input
-              type="search"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Busque receitas ou peça uma nova criação ao atelier"
-              aria-label="Buscar receitas"
-            />
+      <div className="topbar__glass" role="search">
+        <form onSubmit={handleSearch} className="topbar__search">
+          <label className="sr-only" htmlFor="recipe-search">
+            Buscar receitas
+          </label>
+          <input
+            id="recipe-search"
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Busque receitas ou peça uma nova criação ao atelier"
+            aria-label="Buscar receitas"
+          />
+          <div className="topbar__search-actions">
+            {query ? (
+              <button
+                type="button"
+                className="topbar__clear"
+                onClick={() => {
+                  setQuery('');
+                  const params = new URLSearchParams(location.search);
+                  params.delete('q');
+                  navigate({ pathname: location.pathname, search: params.toString() });
+                }}
+              >
+                Limpar
+              </button>
+            ) : null}
             <button type="submit" className="button button--primary topbar__search-button">
               Pesquisar
             </button>
-          </form>
-        </div>
-
-        <div className="topbar__meta" aria-label="Resumo das receitas">
-          <span className="topbar__chip">
-            {recipes.length} {recipes.length === 1 ? 'receita' : 'receitas'}
-          </span>
-          <span className="topbar__chip">
-            {favoriteCount} {favoriteCount === 1 ? 'favorita' : 'favoritas'}
-          </span>
-          {view === 'favorites' ? (
-            <span className="topbar__chip topbar__chip--accent">Filtrando favoritas</span>
-          ) : null}
-        </div>
+          </div>
+        </form>
       </div>
     </header>
   );

--- a/frontend/src/components/layout/layout.css
+++ b/frontend/src/components/layout/layout.css
@@ -1,24 +1,24 @@
 .app-shell {
-  --shell-padding-y: clamp(1.05rem, 2.2vw, 2.1rem);
-  --shell-padding-x: clamp(0.45rem, 1.6vw, 1.35rem);
+  --shell-padding-y: clamp(1.2rem, 3vw, 2.2rem);
+  --shell-padding-x: clamp(1rem, 3vw, 2.6rem);
+  --shell-bottom-gap: clamp(3.5rem, 6vw, 4.75rem);
   display: grid;
-  grid-template-columns: 260px minmax(0, 1fr) 340px;
+  grid-template-columns: minmax(0, 1fr) clamp(300px, 28vw, 360px);
   grid-template-rows: auto minmax(0, 1fr);
   grid-template-areas:
-    'sidebar header chat'
-    'sidebar main chat';
-  gap: clamp(1.2rem, 2.4vw, 2.3rem);
-  padding: var(--shell-padding-y) var(--shell-padding-x);
+    'header header'
+    'main chat';
+  gap: clamp(1.6rem, 3vw, 2.6rem);
+  padding: var(--shell-padding-y) var(--shell-padding-x) var(--shell-bottom-gap);
   width: 100%;
   margin: 0 auto;
+  max-width: 1380px;
   align-items: start;
-  transition: grid-template-columns 0.35s cubic-bezier(.4,0,.2,1);
-  max-width: 1600px;
 }
 
 .app-shell--cooking {
-  --shell-padding-y: clamp(0.5rem, 1.4vw, 1rem);
-  --shell-padding-x: clamp(0.6rem, 3.6vw, 1.4rem);
+  --shell-padding-y: clamp(0.8rem, 2vw, 1.4rem);
+  --shell-padding-x: clamp(0.9rem, 2.6vw, 1.6rem);
   --cooking-header-height: 72px;
   --cooking-top-gap: clamp(1rem, 3vw, 1.65rem);
   grid-template-columns: minmax(0, 1fr);
@@ -26,7 +26,7 @@
   grid-template-areas:
     'header'
     'main';
-  gap: clamp(0.75rem, 2vw, 1.2rem);
+  gap: clamp(0.85rem, 2.6vw, 1.4rem);
   max-width: none;
   padding: var(--shell-padding-y) var(--shell-padding-x);
   margin: 0;
@@ -34,27 +34,14 @@
 }
 
 body.chat-focus .app-shell {
-  grid-template-columns: 72px minmax(0, 1fr) 1fr;
-}
-
-.sidebar-area {
-  grid-area: sidebar;
-  align-self: start;
-  position: sticky;
-  top: var(--shell-padding-y);
-  z-index: 10;
-}
-
-.app-shell--cooking .sidebar-area,
-.app-shell--cooking .chat-area {
-  display: none;
+  grid-template-columns: minmax(0, 1fr) clamp(320px, 30vw, 420px);
 }
 
 .header-area {
   grid-area: header;
   position: sticky;
-  top: calc(var(--shell-padding-y) - 0.5rem);
-  z-index: 30;
+  top: calc(var(--shell-padding-y) - 0.4rem);
+  z-index: 40;
 }
 
 .app-shell--cooking .header-area {
@@ -66,7 +53,6 @@ body.chat-focus .app-shell {
 .main-area {
   grid-area: main;
   min-height: 0;
-  padding-bottom: 6rem;
 }
 
 .app-shell--cooking .main-area {
@@ -82,192 +68,90 @@ body.chat-focus .app-shell {
   top: var(--shell-padding-y);
   height: calc(100vh - var(--shell-padding-y) * 2);
   max-height: calc(100vh - var(--shell-padding-y) * 2);
-  transition: height 0.35s cubic-bezier(.4,0,.2,1), box-shadow 0.35s cubic-bezier(.4,0,.2,1);
-}
-
-.sidebar {
-  min-height: calc(100vh - var(--shell-padding-y) * 2);
-  display: flex;
-  flex-direction: column;
-  gap: 1.9rem;
-  padding: 2rem 1.75rem;
-  border-radius: var(--radius-xl);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border-strong);
-  box-shadow: var(--shadow-xs);
-  backdrop-filter: blur(var(--blur-strong));
-  transition: width 0.35s cubic-bezier(.4,0,.2,1), min-width 0.35s cubic-bezier(.4,0,.2,1), padding 0.35s cubic-bezier(.4,0,.2,1);
-}
-
-.sidebar__brand {
-  display: flex;
-  align-items: center;
-  gap: 1.1rem;
-}
-
-.sidebar__brand-text {
-  display: grid;
-  gap: 0.25rem;
-}
-
-.sidebar__avatar {
-  width: 56px;
-  height: 56px;
-  border-radius: 20px;
-  background: radial-gradient(circle at 35% 25%, rgba(255, 255, 255, 0.68), transparent 55%),
-    linear-gradient(135deg, rgba(155, 89, 182, 0.8), rgba(232, 93, 4, 0.85));
-  color: #fff;
-  display: grid;
-  place-items: center;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  font-size: 1.2rem;
-}
-
-.sidebar__welcome {
-  margin: 0;
-  font-weight: 600;
-  font-size: 1.05rem;
-  color: var(--color-heading);
-}
-
-.sidebar__email {
-  margin: 0.25rem 0 0;
-  font-size: 0.85rem;
-  color: var(--color-muted);
-}
-
-.sidebar__nav {
-  display: grid;
-  gap: 0.6rem;
-}
-
-.sidebar-link {
-  display: flex;
-  align-items: center;
-  gap: 0.85rem;
-  padding: 0.9rem 1.1rem;
-  border-radius: var(--radius-md);
-  font-weight: 600;
-  color: var(--color-muted);
-  background: var(--color-chip-bg);
-  border: 1px solid transparent;
-  transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease, border 0.25s ease;
-  position: relative;
-  overflow: hidden;
-}
-
-.sidebar-link::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(232, 93, 4, 0.18), transparent 70%);
-  opacity: 0;
-  transition: opacity 0.25s ease;
-}
-
-.sidebar-link__icon {
-  width: 36px;
-  height: 36px;
-  border-radius: 12px;
-  display: grid;
-  place-items: center;
-  background: rgba(155, 89, 182, 0.12);
-  color: var(--color-secondary);
-  font-size: 1rem;
-  font-weight: 600;
-}
-
-.sidebar-link__icon svg {
-  width: 22px;
-  height: 22px;
-  display: block;
-}
-
-.sidebar-link__label {
-  flex: 1;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-}
-
-.sidebar-link:hover {
-  background: rgba(232, 93, 4, 0.06);
-  color: var(--color-heading);
-  transform: translateX(4px);
-}
-
-.sidebar-link:hover::after {
-  opacity: 1;
-}
-
-.sidebar-link--active {
-  background: rgba(232, 93, 4, 0.12);
-  border-color: rgba(232, 93, 4, 0.2);
-  color: var(--color-heading);
-  box-shadow: inset 0 0 0 1px rgba(232, 93, 4, 0.12);
-}
-
-body.chat-focus .sidebar {
-  padding: 1rem 0.4rem;
-  align-items: center;
   gap: 1.25rem;
-  width: 100%;
-  min-width: 0;
 }
 
-body.chat-focus .sidebar__brand-text {
+.app-shell--cooking .chat-area {
   display: none;
 }
 
-body.chat-focus .sidebar__avatar {
-  width: 48px;
-  height: 48px;
-  border-radius: 18px;
+@media (max-width: 1280px) {
+  .app-shell {
+    grid-template-columns: minmax(0, 1fr) clamp(280px, 32vw, 340px);
+  }
 }
 
-body.chat-focus .sidebar__nav {
-  justify-items: center;
-  width: 100%;
+@media (max-width: 1100px) {
+  .app-shell {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      'header'
+      'main'
+      'chat';
+    max-width: 1200px;
+  }
+
+  .chat-area {
+    position: static;
+    height: auto;
+    max-height: none;
+  }
 }
 
-body.chat-focus .sidebar-link {
-  padding: 0.75rem;
-  justify-content: center;
-  width: 100%;
+@media (max-width: 960px) {
+  .app-shell {
+    grid-template-areas:
+      'header'
+      'main';
+    gap: clamp(1.35rem, 4vw, 2.1rem);
+    padding: clamp(1.1rem, 4vw, 1.65rem) clamp(0.85rem, 6vw, 1.6rem) calc(6.75rem + env(safe-area-inset-bottom));
+    max-width: 100%;
+  }
+
+  .header-area {
+    position: static;
+  }
+
+  .chat-area {
+    display: none;
+  }
+
+  .main-area {
+    padding-bottom: clamp(4.75rem, 12vw, 6.25rem);
+  }
 }
 
-body.chat-focus .sidebar-link__label {
-  display: none;
-}
-
-body.chat-focus .sidebar-link__icon {
-  width: 44px;
-  height: 44px;
-  border-radius: 16px;
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .topbar {
-  position: relative;
   display: flex;
   justify-content: center;
-  padding: clamp(0.75rem, 2vw, 1.6rem) clamp(0.75rem, 3vw, 1.6rem) 0;
+  padding: clamp(0.75rem, 2.2vw, 1.45rem) clamp(1rem, 3vw, 1.8rem) 0;
 }
 
 .topbar__glass {
   position: relative;
-  display: grid;
-  gap: clamp(1rem, 2.8vw, 1.8rem);
-  width: min(100%, 920px);
-  padding: clamp(1.35rem, 3vw, 2.15rem);
-  border-radius: clamp(1.6rem, 4vw, 2.6rem);
+  display: flex;
+  align-items: center;
+  width: min(100%, 760px);
+  padding: clamp(0.85rem, 2.4vw, 1.35rem) clamp(1.1rem, 3vw, 1.75rem);
+  border-radius: clamp(1.4rem, 3.2vw, 2.1rem);
   background: var(--topbar-glass-bg);
   border: 1px solid var(--topbar-glass-border);
   box-shadow: var(--topbar-glass-shadow);
   backdrop-filter: blur(28px) saturate(170%);
   -webkit-backdrop-filter: blur(28px) saturate(170%);
   overflow: hidden;
-  transition: background 0.3s ease, border 0.3s ease, box-shadow 0.3s ease;
 }
 
 .topbar__glass::before {
@@ -284,263 +168,109 @@ body.chat-focus .sidebar-link__icon {
   z-index: 1;
 }
 
-.topbar__header {
-  display: flex;
-  align-items: flex-start;
-  gap: clamp(1rem, 2.4vw, 1.8rem);
-}
-
-.topbar__titles {
-  display: grid;
-  gap: 0.35rem;
-}
-
-.topbar__eyebrow {
-  font-size: 0.85rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-eyebrow);
-}
-
-.topbar__title {
-  margin: 0;
-  font-size: clamp(1.9rem, 5vw, 2.6rem);
-  font-family: 'Playfair Display', 'Times New Roman', serif;
-  letter-spacing: -0.02em;
-}
-
-.topbar__subtitle {
-  margin: 0;
-  color: var(--color-muted);
-  font-size: clamp(0.95rem, 2.6vw, 1.05rem);
-  max-width: 42ch;
-}
-
-.topbar__actions {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-left: auto;
-}
-
-.topbar__theme-toggle {
-  width: 44px;
-  height: 44px;
-  border-radius: 16px;
-  padding: 0;
-  font-size: 1.1rem;
-  min-width: 44px;
-  background: var(--topbar-toggle-bg);
-  border: 1px solid var(--topbar-toggle-border);
-  box-shadow: var(--topbar-toggle-shadow);
-  color: var(--color-heading);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.topbar__theme-toggle:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--topbar-toggle-shadow-hover);
-}
-
-.topbar__theme-toggle:active {
-  transform: translateY(0);
-}
-
-.topbar__search-card {
-  background: var(--topbar-search-card-bg);
-  border: 1px solid var(--topbar-search-card-border);
-  border-radius: var(--radius-xl);
-  padding: clamp(0.85rem, 2.6vw, 1.1rem) clamp(1rem, 3vw, 1.5rem);
-  box-shadow: var(--topbar-search-card-shadow);
-}
-
 .topbar__search {
+  width: 100%;
   display: flex;
   align-items: center;
-  gap: clamp(0.7rem, 2vw, 1rem);
+  gap: clamp(0.65rem, 2vw, 1.25rem);
+  padding: clamp(0.55rem, 1.6vw, 0.85rem) clamp(0.75rem, 2vw, 1.2rem);
+  border-radius: clamp(1.1rem, 2.8vw, 1.65rem);
+  background: var(--topbar-search-bg);
+  border: 1px solid var(--topbar-search-border);
+  box-shadow: var(--topbar-search-shadow);
+}
+
+.topbar__search:focus-within {
+  background: var(--topbar-search-focus-bg);
+  border-color: var(--topbar-search-focus-border);
+  box-shadow: var(--topbar-search-shadow), 0 18px 38px -28px var(--topbar-search-focus-shadow);
 }
 
 .topbar__search input {
   flex: 1;
   border: none;
   background: transparent;
-  padding: 0.4rem 0;
   font-size: 1rem;
+  color: var(--color-text);
+}
+
+.topbar__search input::placeholder {
+  color: rgba(31, 37, 40, 0.55);
+}
+
+:root[data-theme='dark'] .topbar__search input::placeholder {
+  color: rgba(236, 240, 247, 0.55);
 }
 
 .topbar__search input:focus {
   outline: none;
 }
 
-.topbar__search-card:focus-within {
-  border-color: var(--topbar-search-focus-border);
-  box-shadow: var(--topbar-search-card-shadow), 0 18px 38px -28px var(--topbar-search-focus-shadow);
+.topbar__search-actions {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.5rem, 2vw, 0.9rem);
 }
 
-.topbar__search:focus-within {
-  background: var(--topbar-search-focus-bg);
-  border-color: var(--topbar-search-focus-border);
-  box-shadow: var(--topbar-search-shadow), 0 16px 34px -26px var(--topbar-search-focus-shadow);
+.topbar__clear {
+  border: none;
+  background: none;
+  color: var(--color-muted);
+  font-weight: 600;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.topbar__clear:hover,
+.topbar__clear:focus-visible {
+  color: var(--color-heading);
+  background: rgba(232, 93, 4, 0.12);
+}
+
+.topbar__clear:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(232, 93, 4, 0.25);
 }
 
 .topbar__search-button {
-  padding: 0.7rem clamp(1.35rem, 3vw, 1.8rem);
-}
-
-.topbar__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-}
-
-.topbar__chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.45rem 0.95rem;
-  border-radius: 999px;
-  background: var(--topbar-chip-bg);
-  border: 1px solid var(--topbar-chip-border);
-  color: var(--color-muted-strong);
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.topbar__chip--accent {
-  background: var(--topbar-chip-accent-bg);
-  border-color: var(--topbar-chip-accent-border);
-  color: var(--color-heading);
+  padding: 0.7rem clamp(1.4rem, 3vw, 1.95rem);
+  white-space: nowrap;
 }
 
 .topbar--condensed .topbar__glass {
   width: 100%;
-  padding: clamp(0.85rem, 2.2vw, 1.25rem);
+  padding: clamp(0.75rem, 2vw, 1.1rem) clamp(0.9rem, 2.4vw, 1.3rem);
   border-radius: var(--radius-lg);
-  gap: 0.9rem;
 }
 
-.topbar--condensed .topbar__titles,
-.topbar--condensed .topbar__meta {
-  display: none;
+.topbar--condensed .topbar__search {
+  border-radius: var(--radius-md);
 }
 
-.topbar--condensed .topbar__actions {
-  margin-left: 0;
-  justify-content: flex-end;
-}
-
-.topbar--condensed .topbar__search-card {
-  padding: 0.65rem 0.9rem;
-}
-
-@media (max-width: 1350px) {
-  .app-shell {
-    grid-template-columns: 240px minmax(0, 1fr) 320px;
-  }
-}
-
-@media (max-width: 1200px) {
-  .app-shell {
-    grid-template-columns: 220px minmax(0, 1fr);
-    grid-template-areas:
-      'sidebar header'
-      'sidebar main'
-      'sidebar chat';
-  }
-
-  .chat-area {
-    position: static;
-    height: auto;
-  }
-}
-
-@media (max-width: 1024px) {
-  .app-shell {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto auto auto;
-    grid-template-areas:
-      'header'
-      'sidebar'
-      'main';
-  }
-
-  .chat-area {
-    grid-area: main;
-    position: static;
-    height: auto;
-    margin-top: 2.5rem;
-  }
-
-  .sidebar-area,
-  .header-area {
-    position: static;
-  }
-
-  .main-area {
-    padding-bottom: 4rem;
-  }
-}
-
-@media (max-width: 960px) {
-  .sidebar-area {
-    display: none;
-  }
-
-  .app-shell {
-    grid-template-areas:
-      'header'
-      'main';
-    gap: 1.6rem;
-  }
-
-  .topbar__header {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .topbar__actions {
-    margin-left: 0;
-    align-self: flex-end;
-  }
-}
-
-@media (max-width: 780px) {
-  .sidebar {
-    min-height: auto;
+@media (max-width: 720px) {
+  .topbar {
+    padding: clamp(0.9rem, 4vw, 1.3rem) clamp(0.85rem, 6vw, 1.5rem) 0;
   }
 
   .topbar__glass {
     border-radius: var(--radius-xl);
-  }
-}
-
-@media (max-width: 640px) {
-  .app-shell {
-    padding: 1.1rem 0.75rem 6.25rem;
-    gap: 1.2rem;
-  }
-
-  .topbar__glass {
-    padding: 1.1rem 1.3rem;
-    gap: 1rem;
-  }
-
-  .topbar__titles {
-    gap: 0.25rem;
+    width: 100%;
   }
 
   .topbar__search {
     flex-direction: column;
     align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .topbar__search-actions {
+    justify-content: flex-end;
   }
 
   .topbar__search-button {
     width: 100%;
-  }
-
-  .topbar__actions {
-    align-self: flex-end;
   }
 }
 
@@ -548,7 +278,7 @@ body.chat-focus .sidebar-link__icon {
   position: fixed;
   left: 0;
   right: 0;
-  bottom: calc(0.85rem + env(safe-area-inset-bottom));
+  bottom: calc(1rem + env(safe-area-inset-bottom));
   z-index: 120;
   display: none;
   padding: 0 clamp(0.75rem, 6vw, 2rem);
@@ -556,50 +286,55 @@ body.chat-focus .sidebar-link__icon {
 }
 
 .bottom-nav__inner {
-  max-width: 520px;
+  width: min(100%, 540px);
   margin: 0 auto;
   background: var(--bottom-nav-bg);
   border: 1px solid var(--bottom-nav-border);
-  border-radius: 999px;
+  border-radius: clamp(1.9rem, 6vw, 2.8rem);
   box-shadow: var(--bottom-nav-shadow);
   backdrop-filter: blur(28px) saturate(180%);
   -webkit-backdrop-filter: blur(28px) saturate(180%);
-  padding: 0.35rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.35rem;
+  padding: clamp(0.4rem, 1.8vw, 0.75rem) clamp(0.5rem, 2vw, 1rem);
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  align-items: end;
   pointer-events: auto;
+  position: relative;
 }
 
 .bottom-nav__item {
-  flex: 1;
-  display: grid;
-  grid-template-rows: auto auto;
-  gap: 0.25rem;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-items: center;
-  padding: 0.55rem 0.4rem;
-  border-radius: 999px;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.3rem;
+  border-radius: 18px;
   color: var(--color-muted);
   text-decoration: none;
-  font-size: 0.75rem;
+  font-size: 0.78rem;
   font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  transition: color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  transition: color 0.2s ease;
+  position: relative;
+  z-index: 1;
 }
 
 .bottom-nav__item:focus-visible {
   outline: 2px solid var(--topbar-search-focus-border);
-  outline-offset: 2px;
+  outline-offset: 3px;
 }
 
 .bottom-nav__item:hover {
-  transform: translateY(-1px);
+  color: var(--color-heading);
 }
 
 .bottom-nav__item--active {
+  color: var(--bottom-nav-active-color);
+}
+
+.bottom-nav__item--active:not(.bottom-nav__item--import) .bottom-nav__icon {
   background: var(--bottom-nav-active-bg);
   color: var(--bottom-nav-active-color);
   box-shadow: inset 0 0 0 1px var(--bottom-nav-active-border);
@@ -608,22 +343,47 @@ body.chat-focus .sidebar-link__icon {
 .bottom-nav__icon {
   display: grid;
   place-items: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 12px;
+  width: 34px;
+  height: 34px;
+  border-radius: 14px;
   background: var(--bottom-nav-icon-bg);
   color: currentColor;
+  transition: transform 0.2s ease, background 0.2s ease;
 }
 
 .bottom-nav__icon svg {
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
   display: block;
 }
 
 .bottom-nav__label {
-  font-size: 0.65rem;
-  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.bottom-nav__item--import {
+  margin-top: -2.2rem;
+  gap: 0.55rem;
+  font-weight: 700;
+}
+
+.bottom-nav__item--import .bottom-nav__icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 999px;
+  background: var(--gradient-brand);
+  color: #fff;
+  box-shadow: 0 28px 48px -26px rgba(232, 93, 4, 0.6);
+}
+
+.bottom-nav__item--import .bottom-nav__label {
+  font-size: 0.78rem;
+  color: var(--color-heading);
+}
+
+:root[data-theme='dark'] .bottom-nav__item--import .bottom-nav__label {
+  color: #fff;
 }
 
 @media (max-width: 960px) {

--- a/frontend/src/components/recipes/RecipeCard.tsx
+++ b/frontend/src/components/recipes/RecipeCard.tsx
@@ -15,29 +15,42 @@ const RecipeCard = ({ recipe, onOpen, onToggleFavorite }: RecipeCardProps) => {
       return { backgroundImage: `url(${recipe.coverImage})` };
     }
     return {
-      background:
+      backgroundImage:
         'linear-gradient(135deg, rgba(155, 89, 182, 0.28), rgba(232, 93, 4, 0.28)), url(https://images.unsplash.com/photo-1473091534298-04dcbce3278c?auto=format&fit=crop&w=1200&q=60)'
     };
   }, [recipe.coverImage]);
 
+  const lastTouched = recipe.updatedAt ?? recipe.createdAt;
+  const formattedDate = useMemo(() => {
+    if (!lastTouched) return '';
+    try {
+      return new Intl.DateTimeFormat('pt-BR', {
+        day: '2-digit',
+        month: 'short'
+      }).format(new Date(lastTouched));
+    } catch {
+      return '';
+    }
+  }, [lastTouched]);
+
   return (
     <article className="recipe-card">
-      <div className="recipe-card__cover" style={coverStyle}>
-        <button
-          type="button"
-          className={`recipe-card__favorite ${recipe.isFavorite ? 'is-favorite' : ''}`}
-          onClick={() => onToggleFavorite(recipe.id)}
-          aria-pressed={recipe.isFavorite}
-          aria-label={recipe.isFavorite ? 'Remover dos favoritos' : 'Adicionar aos favoritos'}
-        >
-          <span className="recipe-card__favorite-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" focusable="false">
-              <path d="M12 17.3l6.18 3.86-1.64-7.03L21.5 9.9l-7.19-.62L12 2.7 9.69 9.28 2.5 9.9l4.96 4.23-1.64 7.03z" />
-            </svg>
-          </span>
-        </button>
+      <div className="recipe-card__media" style={coverStyle} aria-hidden="true">
+        <span className="recipe-card__media-overlay" />
       </div>
-      <div className="recipe-card__content">
+
+      <button
+        type="button"
+        className={`recipe-card__favorite${recipe.isFavorite ? ' is-favorite' : ''}`}
+        onClick={() => onToggleFavorite(recipe.id)}
+        aria-pressed={recipe.isFavorite}
+        aria-label={recipe.isFavorite ? 'Remover dos favoritos' : 'Adicionar aos favoritos'}
+      >
+        <span aria-hidden="true">★</span>
+      </button>
+
+      <div className="recipe-card__body">
+        {formattedDate ? <span className="recipe-card__timestamp">Atualizada em {formattedDate}</span> : null}
         <h3>{recipe.title}</h3>
         <p>{recipe.description ?? 'Receita recém importada esperando sua assinatura pessoal.'}</p>
         <div className="recipe-card__meta">
@@ -45,13 +58,33 @@ const RecipeCard = ({ recipe, onOpen, onToggleFavorite }: RecipeCardProps) => {
           {recipe.servings ? <span>🍽️ {recipe.servings} porções</span> : null}
           {recipe.difficulty ? <span>🔥 {recipe.difficulty}</span> : null}
         </div>
-      </div>
-      <div className="recipe-card__actions">
-        <button type="button" className="button button--primary" onClick={() => onOpen(recipe.id)}>
-          Abrir receita
-        </button>
-        <button type="button" className="recipe-card__cta" onClick={() => onToggleFavorite(recipe.id)}>
-          {recipe.isFavorite ? 'Remover dos favoritos' : 'Guardar como favorita'}
+        <button
+          type="button"
+          className="recipe-card__open"
+          onClick={() => onOpen(recipe.id)}
+          aria-label={`Abrir detalhes da receita ${recipe.title}`}
+        >
+          Ver detalhes
+          <span aria-hidden="true" className="recipe-card__open-icon">
+            <svg viewBox="0 0 24 24" focusable="false">
+              <path
+                d="M8 5h11v11"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M8 16 19 5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </span>
         </button>
       </div>
     </article>

--- a/frontend/src/components/recipes/recipes.css
+++ b/frontend/src/components/recipes/recipes.css
@@ -1,137 +1,127 @@
 .recipe-grid {
   display: grid;
-  gap: 1.8rem;
+  gap: clamp(1.4rem, 3vw, 2rem);
 }
 
 .recipe-card {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  position: relative;
+  display: flex;
+  flex-direction: column;
   background: var(--color-surface);
-  border-radius: 28px;
+  border-radius: clamp(1.6rem, 3vw, 2.3rem);
   overflow: hidden;
   border: 1px solid var(--color-border-strong);
-  box-shadow: 0 36px 60px -40px rgba(32, 40, 42, 0.55);
-  transition: transform 0.35s cubic-bezier(.22,1,.36,1), box-shadow 0.35s cubic-bezier(.22,1,.36,1);
-  position: relative;
-}
-
-.recipe-card::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(155, 89, 182, 0.2), rgba(232, 93, 4, 0.12));
-  opacity: 0;
-  transition: opacity 0.35s ease;
-  pointer-events: none;
+  box-shadow: 0 38px 80px -58px rgba(18, 24, 42, 0.55);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .recipe-card:hover {
-  transform: translateY(-6px) scale(1.01);
-  box-shadow: 0 56px 100px -56px rgba(45, 52, 54, 0.65);
+  transform: translateY(-6px);
+  box-shadow: 0 48px 96px -56px rgba(18, 24, 42, 0.65);
 }
 
-.recipe-card:hover::after {
-  opacity: 0.5;
-}
-
-.recipe-card__cover {
+.recipe-card__media {
   position: relative;
-  height: clamp(220px, 40vh, 320px);
+  height: clamp(180px, 32vw, 240px);
   background-size: cover;
   background-position: center;
-  overflow: hidden;
 }
 
-.recipe-card__cover::before {
-  content: '';
+.recipe-card__media-overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(14, 14, 14, 0.05), rgba(14, 14, 14, 0.5));
+  background: linear-gradient(180deg, rgba(18, 22, 30, 0.08), rgba(18, 22, 30, 0.65));
+  mix-blend-mode: multiply;
 }
 
 .recipe-card__favorite {
   position: absolute;
-  top: 1.4rem;
-  right: 1.4rem;
+  top: 1.3rem;
+  right: 1.3rem;
   width: 48px;
   height: 48px;
-  border: none;
   border-radius: 18px;
-  background: var(--color-surface-strong);
-  border: 1px solid var(--color-border-soft);
-  backdrop-filter: blur(16px);
-  box-shadow: 0 22px 34px -26px rgba(32, 40, 42, 0.55);
-  cursor: pointer;
+  border: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--color-muted);
   display: grid;
   place-items: center;
-  transition: transform 0.25s ease, background 0.25s ease, box-shadow 0.25s ease;
+  cursor: pointer;
+  box-shadow: 0 22px 46px -30px rgba(18, 24, 42, 0.4);
+  transition: transform 0.25s ease, background 0.25s ease, color 0.25s ease;
 }
 
 .recipe-card__favorite:hover {
-  transform: translateY(-4px) scale(1.05);
-}
-
-.recipe-card__favorite svg {
-  width: 20px;
-  height: 20px;
-  fill: rgba(232, 93, 4, 0.45);
-  transition: fill 0.25s ease;
+  transform: translateY(-3px);
+  background: rgba(232, 93, 4, 0.16);
+  color: var(--color-primary);
 }
 
 .recipe-card__favorite.is-favorite {
-  background: rgba(232, 93, 4, 0.16);
+  background: rgba(232, 93, 4, 0.2);
+  border-color: rgba(232, 93, 4, 0.4);
+  color: var(--color-primary-strong);
 }
 
-.recipe-card__favorite.is-favorite svg {
-  fill: var(--color-primary);
-}
-
-.recipe-card__content {
+.recipe-card__body {
   display: grid;
-  gap: 1rem;
-  padding: clamp(1.5rem, 2vw, 2.25rem) clamp(1.75rem, 3vw, 2.75rem);
+  gap: 0.85rem;
+  padding: clamp(1.5rem, 3vw, 2.1rem) clamp(1.6rem, 3vw, 2.4rem) clamp(1.6rem, 3vw, 2.2rem);
 }
 
-.recipe-card__content h3 {
+.recipe-card__timestamp {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-eyebrow);
+}
+
+.recipe-card__body h3 {
   margin: 0;
-  font-size: clamp(1.5rem, 3vw, 1.9rem);
-  line-height: 1.25;
   font-family: 'Playfair Display', 'Times New Roman', serif;
+  font-size: clamp(1.4rem, 3vw, 1.9rem);
+  line-height: 1.3;
 }
 
-.recipe-card__content p {
+.recipe-card__body p {
   margin: 0;
   color: var(--color-muted);
-  font-size: 0.95rem;
+  font-size: 0.98rem;
+  line-height: 1.6;
 }
 
 .recipe-card__meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.6rem 1.2rem;
+  gap: 0.6rem 1.1rem;
   font-size: 0.85rem;
   color: var(--color-muted);
 }
 
-.recipe-card__actions {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0  clamp(1.75rem, 3vw, 2.75rem) clamp(1.75rem, 3vw, 2.5rem);
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.recipe-card__cta {
+.recipe-card__open {
+  margin-top: 0.3rem;
+  align-self: flex-start;
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  color: var(--color-primary);
-  font-weight: 600;
-  cursor: pointer;
-  background: none;
+  gap: 0.45rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
   border: none;
-  padding: 0;
+  background: rgba(232, 93, 4, 0.14);
+  color: var(--color-primary-strong);
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.recipe-card__open:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px -26px rgba(232, 93, 4, 0.45);
+}
+
+.recipe-card__open-icon svg {
+  width: 18px;
+  height: 18px;
 }
 
 .empty-state {
@@ -143,34 +133,19 @@
   background: var(--color-surface-muted);
 }
 
-@media (max-width: 640px) {
+@media (max-width: 720px) {
   .recipe-card {
-    border-radius: 24px;
+    border-radius: var(--radius-xl);
   }
 
-  .recipe-card__actions {
-    padding: 0 clamp(1.2rem, 3vw, 2rem) clamp(1.4rem, 3vw, 2rem);
-    flex-direction: column;
-    align-items: stretch;
+  .recipe-card__body {
+    padding: clamp(1.35rem, 5vw, 1.8rem) clamp(1.3rem, 5vw, 1.9rem) clamp(1.5rem, 5vw, 1.9rem);
   }
-}
 
-.recipe-player {
-  padding: 0;
-  overflow: hidden;
-  border-radius: 28px;
-}
-
-.recipe-player iframe {
-  width: 100%;
-  height: clamp(280px, 45vh, 420px);
-  border: none;
-  display: block;
-}
-
-.recipe-player__empty {
-  display: grid;
-  place-items: center;
-  min-height: 200px;
-  color: var(--color-muted);
+  .recipe-card__favorite {
+    width: 44px;
+    height: 44px;
+    top: 1rem;
+    right: 1rem;
+  }
 }

--- a/frontend/src/pages/home.css
+++ b/frontend/src/pages/home.css
@@ -1,154 +1,215 @@
-.atelier {
+.timeline {
   display: grid;
-  gap: clamp(1.75rem, 3vw, 2.75rem);
-  position: relative;
+  gap: clamp(2rem, 4vw, 3rem);
 }
 
-.atelier__welcome {
-  display: grid;
-  gap: clamp(1.75rem, 3vw, 2.5rem);
+.timeline__hero {
+  position: relative;
+  padding: clamp(1.8rem, 4vw, 2.9rem);
+  border-radius: clamp(1.8rem, 4vw, 2.9rem);
+  background:
+    radial-gradient(circle at 15% 20%, rgba(232, 93, 4, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(155, 89, 182, 0.4), transparent 60%),
+    linear-gradient(140deg, rgba(23, 28, 45, 0.96), rgba(18, 24, 42, 0.94));
+  color: #f7f8ff;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 40px 90px -55px rgba(18, 24, 42, 0.85);
   overflow: hidden;
 }
 
-.atelier__welcome::before {
+:root[data-theme='dark'] .timeline__hero {
+  background:
+    radial-gradient(circle at 18% 18%, rgba(232, 93, 4, 0.38), transparent 60%),
+    radial-gradient(circle at 82% 12%, rgba(155, 89, 182, 0.45), transparent 65%),
+    linear-gradient(140deg, rgba(23, 20, 38, 0.92), rgba(16, 12, 28, 0.94));
+  border-color: rgba(236, 240, 247, 0.28);
+}
+
+.timeline__hero::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 85% 15%, rgba(232, 93, 4, 0.22), transparent 55%),
-    radial-gradient(circle at 10% 85%, rgba(155, 89, 182, 0.28), transparent 60%);
-  opacity: 0.4;
+  background: radial-gradient(circle at 65% 70%, rgba(255, 255, 255, 0.18), transparent 68%);
+  mix-blend-mode: screen;
+  opacity: 0.6;
   pointer-events: none;
 }
 
-.atelier__welcome > * {
+.timeline__hero-inner {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 0.85rem;
+  max-width: 52ch;
+}
+
+.timeline__hero-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.timeline__hero-title {
+  margin: 0;
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  font-size: clamp(2.1rem, 5vw, 2.9rem);
+  line-height: 1.2;
+}
+
+.timeline__hero-subtitle {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.76);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.timeline__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  color: rgba(255, 255, 255, 0.92);
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+}
+
+.timeline__saved {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline__saved-header {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.timeline__saved-header h2 {
+  margin: 0;
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+}
+
+.timeline__saved-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(220px, 260px);
+  gap: clamp(1rem, 2vw, 1.35rem);
+  overflow-x: auto;
+  padding-bottom: 0.35rem;
+  scroll-snap-type: x mandatory;
+}
+
+.timeline__saved-list::-webkit-scrollbar {
+  height: 6px;
+}
+
+.timeline__saved-list::-webkit-scrollbar-thumb {
+  background: rgba(31, 37, 40, 0.25);
+  border-radius: 999px;
+}
+
+.timeline__saved-item {
+  position: relative;
+  scroll-snap-align: start;
+}
+
+.timeline__saved-card {
+  position: relative;
+  width: 100%;
+  min-height: 240px;
+  border-radius: clamp(1.4rem, 3vw, 2rem);
+  background-size: cover;
+  background-position: center;
+  border: none;
+  padding: clamp(1.1rem, 3vw, 1.6rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  text-align: left;
+  color: #fff;
+  overflow: hidden;
+  box-shadow: 0 28px 60px -38px rgba(18, 24, 42, 0.65);
+  cursor: pointer;
+}
+
+.timeline__saved-card-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(18, 22, 30, 0) 20%, rgba(18, 22, 30, 0.75) 100%);
+  z-index: 0;
+}
+
+.timeline__saved-card-title,
+.timeline__saved-card-meta {
   position: relative;
   z-index: 1;
 }
 
-.atelier__welcome-header {
-  display: flex;
-  justify-content: space-between;
-  gap: clamp(1.5rem, 3vw, 3rem);
-  flex-wrap: wrap;
-  align-items: flex-start;
-}
-
-.atelier__welcome-header h2 {
-  font-size: clamp(2.1rem, 4vw, 2.75rem);
-  line-height: 1.2;
-}
-
-.atelier__stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 1rem;
-  background: rgba(255, 255, 255, 0.28);
-  border-radius: var(--radius-md);
-  padding: 1.1rem 1.25rem;
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  box-shadow: inset 0 0 0 1px rgba(232, 93, 4, 0.06);
-}
-
-.atelier__stats div {
-  display: grid;
-  gap: 0.2rem;
-  text-align: center;
-}
-
-.atelier__stats dt {
-  font-size: 0.85rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(45, 52, 54, 0.6);
-}
-
-.atelier__stats dd {
-  margin: 0;
-  font-size: 2rem;
+.timeline__saved-card-title {
+  font-size: 1.05rem;
   font-weight: 700;
-  color: var(--color-heading);
+  line-height: 1.4;
 }
 
-.atelier__stats span {
+.timeline__saved-card-meta {
   font-size: 0.85rem;
-  color: var(--color-muted);
+  color: rgba(255, 255, 255, 0.82);
 }
 
-.atelier__capsules {
-  display: flex;
-  gap: 1rem;
-  overflow-x: auto;
-  padding-bottom: 0.25rem;
-  scroll-snap-type: x mandatory;
-}
-
-.atelier__capsules::-webkit-scrollbar {
-  height: 6px;
-}
-
-.atelier__capsule {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.9rem;
-  padding: 0.9rem 1.4rem;
-  border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.68);
-  border: 1px solid rgba(232, 93, 4, 0.1);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
-  cursor: pointer;
-  scroll-snap-align: start;
-  transition: transform 0.25s ease, box-shadow 0.25s ease, border 0.25s ease, background 0.25s ease;
-  min-width: 200px;
-}
-
-.atelier__capsule:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 22px 44px -30px rgba(45, 52, 54, 0.55);
-}
-
-.atelier__capsule.is-active {
-  background: rgba(232, 93, 4, 0.16);
-  border-color: rgba(232, 93, 4, 0.32);
-  box-shadow: 0 22px 44px -26px rgba(232, 93, 4, 0.45);
-}
-
-.atelier__capsule strong {
-  display: block;
-  font-size: 1rem;
-  color: var(--color-heading);
-}
-
-.atelier__capsule small {
-  display: block;
-  color: var(--color-muted);
-  font-size: 0.8rem;
-}
-
-.atelier__capsule-icon {
-  width: 42px;
-  height: 42px;
-  border-radius: 15px;
+.timeline__saved-favorite {
+  position: absolute;
+  top: 1.1rem;
+  right: 1.1rem;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: rgba(17, 20, 28, 0.45);
+  color: rgba(255, 255, 255, 0.82);
   display: grid;
   place-items: center;
-  background: rgba(155, 89, 182, 0.15);
-  font-size: 1.2rem;
+  cursor: pointer;
+  transition: transform 0.25s ease, background 0.25s ease, color 0.25s ease;
 }
 
-.atelier__feed {
+.timeline__saved-favorite:hover {
+  transform: translateY(-3px);
+  background: rgba(232, 93, 4, 0.4);
+  color: #fff;
+}
+
+.timeline__saved-favorite.is-active {
+  background: rgba(232, 93, 4, 0.9);
+  border-color: rgba(255, 255, 255, 0.65);
+  color: #fff;
+}
+
+.timeline__feed {
   display: grid;
-  gap: 2rem;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
-.atelier__feed-header {
+.timeline__feed-header {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
-.atelier__feed-header h3 {
+.timeline__feed-header h2 {
+  margin: 0;
+  font-family: 'Playfair Display', 'Times New Roman', serif;
   font-size: clamp(1.8rem, 3vw, 2.4rem);
 }
 
-.atelier__loader {
+.timeline__loader {
   display: grid;
   gap: 1rem;
   justify-items: center;
@@ -156,29 +217,38 @@
   padding: 2.75rem;
 }
 
-.atelier__loader p {
+.timeline__loader p {
   margin: 0;
   color: var(--color-muted);
   font-weight: 500;
 }
 
-@media (max-width: 1024px) {
-  .atelier__welcome-header {
-    flex-direction: column;
+@media (max-width: 960px) {
+  .timeline__saved-list {
+    grid-auto-columns: minmax(200px, 220px);
+  }
+}
+
+@media (max-width: 720px) {
+  .timeline__hero {
+    border-radius: clamp(1.4rem, 6vw, 2.4rem);
   }
 
-  .atelier__stats {
-    width: 100%;
+  .timeline__hero-inner {
+    gap: 0.75rem;
   }
 }
 
 @media (max-width: 640px) {
-  .atelier__capsule {
-    min-width: 180px;
-    padding: 0.8rem 1.2rem;
+  .timeline {
+    gap: clamp(1.6rem, 6vw, 2.4rem);
   }
 
-  .atelier__stats {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  .timeline__hero {
+    padding: clamp(1.5rem, 6vw, 2.2rem);
+  }
+
+  .timeline__saved-list {
+    grid-auto-columns: 75%;
   }
 }


### PR DESCRIPTION
## Summary
- replace the desktop sidebar layout with a mobile-first shell that centers the search-focused top bar
- redesign the home timeline to match the mock, including the hero section, saved-recipe carousel, and compact recipe cards
- refresh the bottom navigation bar with a highlighted import action and responsive styling updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc0b2d26388323bdfeb3a8816ef84b