### PR TITLE
Support multi-session chat persistence

### DIFF
--- a/frontend/src/components/chat/ChatDock.tsx
+++ b/frontend/src/components/chat/ChatDock.tsx
@@ -7,7 +7,7 @@ import MessageBubble from './MessageBubble';
 import './chat.css';
 
 const ChatDock = () => {
-  const { messages, isLoading, isSending, error, sendMessage, hydrate } = useChat();
+  const { messages, isLoading, isSending, error, sendMessage, hydrate, startNewChat } = useChat();
 
   const handleSuggestion = useCallback(
     async (prompt: string) => {
@@ -26,6 +26,13 @@ const ChatDock = () => {
             O chat acompanha cada receita e traz tecnicas, substituicoes e ideias comerciais para o seu livro digital.
           </p>
         </div>
+        <button
+          type="button"
+          className="button button--secondary"
+          onClick={startNewChat}
+        >
+          Nova conversa
+        </button>
 
       </header>
 

--- a/frontend/src/services/chat.ts
+++ b/frontend/src/services/chat.ts
@@ -5,10 +5,12 @@ export interface ChatRequestPayload {
   message: string;
   recipeId?: string;
   threadId?: string;
+  chatId?: string;
 }
 
 export interface ChatResponse {
   message: ChatMessage;
+  userMessage: ChatMessage;
   relatedRecipes?: string[];
   followUpPrompts?: Array<{ label: string; prompt: string }>;
 }
@@ -20,8 +22,10 @@ export const sendChatMessage = (token: string, payload: ChatRequestPayload) =>
     body: JSON.stringify(payload)
   });
 
-export const fetchChatHistory = (token: string) =>
-  apiRequest<ChatMessage[]>('/chat/history', {
+export const fetchChatHistory = (token: string, chatId?: string) => {
+  const query = chatId ? `?chatId=${encodeURIComponent(chatId)}` : '';
+  return apiRequest<ChatMessage[]>(`/chat/history${query}`, {
     method: 'GET',
     authToken: token
   });
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -62,6 +62,7 @@ export interface ChatMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
   createdAt: string;
+  chatId: string;
   relatedRecipeIds?: string[];
   suggestions?: Array<{ label: string; prompt: string }>;
 }

--- a/src/app/schemas/chat.py
+++ b/src/app/schemas/chat.py
@@ -11,6 +11,7 @@ class ChatMessage(BaseModel):
     role: Literal["user", "assistant", "system"]
     content: str
     createdAt: datetime
+    chatId: str
     relatedRecipeIds: Optional[list[str]] = None
     suggestions: Optional[list[dict[str, str]]] = None
 
@@ -19,8 +20,10 @@ class ChatRequest(BaseModel):
     message: str = Field(..., min_length=1)
     recipeId: Optional[str] = None
     threadId: Optional[str] = None
+    chatId: Optional[str] = None
 
 
 class ChatResponse(BaseModel):
     message: ChatMessage
+    userMessage: ChatMessage
 

--- a/src/services/chat_store.py
+++ b/src/services/chat_store.py
@@ -20,7 +20,8 @@ def send_message(
     message: str,
     recipe_id: Optional[str] = None,
     client_message_id: Optional[str] = None,
-) -> Dict[str, Any]:
+    chat_id: Optional[str] = None,
+) -> Dict[str, Dict[str, Any]]:
     """
     Orquestra o processo de resposta do chat:
     1. Salva a mensagem do usuário.
@@ -32,14 +33,26 @@ def send_message(
     user_id = str(user.id)
 
     # 1. Salva a mensagem do usuário no banco de dados
-    persist_supabase.save_chat_message(
+    user_record = persist_supabase.save_chat_message(
         user_id,
         "user",
         message,
         supa,
         recipe_id=recipe_id,
         client_message_id=client_message_id,
+        chat_id=chat_id,
     )
+
+    normalized_chat_id: Optional[str] = None
+    if isinstance(user_record, dict):
+        chat_id_value = user_record.get("chat_id")
+        if chat_id_value:
+            normalized_chat_id = str(chat_id_value)
+
+    if not normalized_chat_id:
+        normalized_chat_id = str(chat_id or uuid4())
+        if isinstance(user_record, dict):
+            user_record["chat_id"] = normalized_chat_id
 
     # 2. Busca o contexto relevante (da receita específica ou por similaridade)
     context_text, context_recipe_ids = get_context(
@@ -54,6 +67,7 @@ def send_message(
         user_id,
         supa,
         limit=MAX_HISTORY_MESSAGES,
+        chat_id=normalized_chat_id,
     )
     history_payload = _build_history_payload(full_history)
 
@@ -72,14 +86,32 @@ def send_message(
         assistant_text,
         supa,
         related_recipe_ids=context_recipe_ids or None,
+        chat_id=normalized_chat_id,
     )
 
-    return _format_chat_message(assistant_record)
+    if isinstance(assistant_record, dict) and "chat_id" not in assistant_record:
+        assistant_record["chat_id"] = normalized_chat_id
+
+    formatted_user = _format_chat_message(user_record)
+    formatted_assistant = _format_chat_message(assistant_record)
+
+    return {"user": formatted_user, "assistant": formatted_assistant}
 
 
-def list_messages(user_id: str, supa: Client, limit: int = 50) -> List[Dict[str, Any]]:
+def list_messages(
+    user_id: str,
+    supa: Client,
+    limit: int = 50,
+    *,
+    chat_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
     """Retorna o histórico do chat no formato esperado pela API."""
-    records = persist_supabase.get_chat_history(user_id, supa, limit=limit)
+    records = persist_supabase.get_chat_history(
+        user_id,
+        supa,
+        limit=limit,
+        chat_id=chat_id,
+    )
     return [_format_chat_message(record) for record in records]
 
 
@@ -207,11 +239,13 @@ def _build_history_payload(records: Sequence[Dict[str, Any]]) -> List[Dict[str, 
 def _format_chat_message(record: Dict[str, Any]) -> Dict[str, Any]:
     """Normaliza o formato da mensagem para o contrato da API."""
     if not record:
+        fallback_chat_id = "legacy-chat"
         return {
             "id": str(uuid4()),
             "role": "assistant",
             "content": "",
             "createdAt": datetime.now(timezone.utc).isoformat(),
+            "chatId": fallback_chat_id,
         }
 
     message_id = (
@@ -220,6 +254,16 @@ def _format_chat_message(record: Dict[str, Any]) -> Dict[str, Any]:
         or record.get("uuid")
         or str(uuid4())
     )
+
+    chat_id_value = (
+        record.get("chat_id")
+        or record.get("thread_id")
+        or record.get("conversation_id")
+    )
+    if chat_id_value:
+        chat_id_str = str(chat_id_value)
+    else:
+        chat_id_str = "legacy-chat"
 
     created_at = record.get("created_at")
     if isinstance(created_at, datetime):
@@ -248,9 +292,10 @@ def _format_chat_message(record: Dict[str, Any]) -> Dict[str, Any]:
 
     return {
         "id": str(message_id),
-        "role": record.get("role", "assistant"),
-        "content": record.get("content", ""),
+        "role": str(record.get("role") or "assistant"),
+        "content": str(record.get("content") or ""),
         "createdAt": created_at_iso,
+        "chatId": chat_id_str,
         "relatedRecipeIds": related_recipe_ids,
         "suggestions": suggestions,
     }

--- a/src/services/persist_supabase.py
+++ b/src/services/persist_supabase.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence
+from uuid import uuid4
 
 from supabase import Client
 
@@ -83,17 +84,21 @@ def find_similar_chunks(
         return []
 
 
-def get_chat_history(user_id: str, supa: Client, limit: int = 50) -> List[Dict[str, Any]]:
+def get_chat_history(
+    user_id: str,
+    supa: Client,
+    limit: int = 50,
+    *,
+    chat_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
     """Busca o histórico de mensagens de um usuário no banco de dados."""
     try:
-        response = (
-            supa.table("chat_messages")
-            .select("*")
-            .eq("user_id", user_id)
-            .order("created_at", desc=True)
-            .limit(limit)
-            .execute()
-        )
+        query = supa.table("chat_messages").select("*").eq("user_id", user_id)
+
+        if chat_id:
+            query = query.eq("chat_id", chat_id)
+
+        response = query.order("created_at", desc=True).limit(limit).execute()
 
         records: List[Dict[str, Any]] = response.data or []
         records.reverse()
@@ -111,6 +116,7 @@ def save_chat_message(
     *,
     recipe_id: Optional[str] = None,
     client_message_id: Optional[str] = None,
+    chat_id: Optional[str] = None,
     related_recipe_ids: Optional[Sequence[str]] = None,
 ) -> Dict[str, Any]:
     """Salva uma única mensagem de chat no banco de dados e retorna o registro salvo."""
@@ -120,6 +126,9 @@ def save_chat_message(
             "role": role,
             "content": content,
         }
+
+        normalized_chat_id = str(chat_id or uuid4())
+        message_data["chat_id"] = normalized_chat_id
 
         normalized_related: List[str] = []
         if recipe_id:
@@ -148,22 +157,31 @@ def save_chat_message(
             result = supa.table("chat_messages").insert(message_data).execute()
 
         data = result.data
+        def _ensure_chat_id(payload: Dict[str, Any]) -> Dict[str, Any]:
+            if "chat_id" not in payload:
+                payload["chat_id"] = normalized_chat_id
+            return payload
+
         if isinstance(data, list) and data:
-            return data[0]
+            return _ensure_chat_id(data[0])
         if isinstance(data, dict) and data:
-            return data
+            return _ensure_chat_id(data)
 
         # Se o Supabase não retornou a linha criada, buscamos a mensagem mais recente do usuário.
         history = (
             supa.table("chat_messages")
             .select("*")
             .eq("user_id", user_id)
+            .eq("chat_id", normalized_chat_id)
             .order("created_at", desc=True)
             .limit(1)
             .execute()
         )
         if history.data:
-            return history.data[0]
+            record = history.data[0]
+            if isinstance(record, dict) and "chat_id" not in record:
+                record["chat_id"] = normalized_chat_id
+            return record
 
         return {}
     except Exception as e:


### PR DESCRIPTION
## Summary
- add chat session identifiers to Supabase persistence and store both user and assistant messages for each turn
- expose chat IDs through the chat API, returning both saved messages per request and allowing history filtering by session
- update the frontend chat context to track the active chat, send the session ID, and provide a "Nova conversa" control

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68de01a216a48323b605cbabc73d8789