### PR TITLE
Improve chat persistence and hydration

### DIFF
--- a/frontend/src/components/chat/ChatDock.tsx
+++ b/frontend/src/components/chat/ChatDock.tsx
@@ -1,4 +1,4 @@
-﻿import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useChat } from '../../context/ChatContext';
 import Loader from '../shared/Loader';
@@ -7,7 +7,44 @@ import MessageBubble from './MessageBubble';
 import './chat.css';
 
 const ChatDock = () => {
-  const { messages, isLoading, isSending, error, sendMessage, hydrate } = useChat();
+  const {
+    messages,
+    sessions,
+    isLoading,
+    isSending,
+    error,
+    sendMessage,
+    startNewChat,
+    activeChatId,
+    selectChat
+  } = useChat();
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat('pt-BR', {
+        day: '2-digit',
+        month: 'short',
+        hour: '2-digit',
+        minute: '2-digit'
+      }),
+    []
+  );
+
+  const formatTabMeta = useCallback(
+    (updatedAt: string, messageCount: number) => {
+      try {
+        const formatted = dateFormatter.format(new Date(updatedAt));
+        if (messageCount <= 0) {
+          return formatted;
+        }
+        return `${formatted} · ${messageCount} mensagens`;
+      } catch (err) {
+        console.error(err);
+        return messageCount > 0 ? `${messageCount} mensagens` : '';
+      }
+    },
+    [dateFormatter]
+  );
 
   const handleSuggestion = useCallback(
     async (prompt: string) => {
@@ -26,8 +63,39 @@ const ChatDock = () => {
             O chat acompanha cada receita e traz tecnicas, substituicoes e ideias comerciais para o seu livro digital.
           </p>
         </div>
-
+        <button
+          type="button"
+          className="button button--secondary"
+          onClick={startNewChat}
+        >
+          Nova conversa
+        </button>
       </header>
+
+      {sessions.length > 1 ? (
+        <div className="chat-dock__tabs" role="tablist" aria-label="Conversas salvas">
+          {sessions.map((session) => {
+            const isActive = session.id === activeChatId;
+            return (
+              <button
+                key={session.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                className={`chat-dock__tab${isActive ? ' is-active' : ''}`}
+                onClick={() => selectChat(session.id)}
+              >
+                <span className="chat-dock__tab-title" title={session.title}>
+                  {session.title}
+                </span>
+                <span className="chat-dock__tab-meta">
+                  {formatTabMeta(session.updatedAt, session.messageCount)}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
 
       <div className="chat-dock__history">
         {isLoading ? (

--- a/frontend/src/components/chat/chat.css
+++ b/frontend/src/components/chat/chat.css
@@ -17,6 +17,54 @@
   border-bottom: 1px solid var(--chat-input-border);
 }
 
+.chat-dock__tabs {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem 0.5rem;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--chat-input-border);
+  background: var(--chat-history-bg);
+}
+
+.chat-dock__tab {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-text);
+  border-radius: var(--radius-md);
+  padding: 0.55rem 0.9rem;
+  min-width: 160px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.chat-dock__tab:hover {
+  border-color: rgba(91, 62, 234, 0.28);
+  background: rgba(91, 62, 234, 0.08);
+}
+
+.chat-dock__tab.is-active {
+  border-color: var(--chat-input-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-xs);
+}
+
+.chat-dock__tab-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-dock__tab-meta {
+  font-size: 0.75rem;
+  color: var(--color-muted);
+}
+
 .chat-dock__header h2 {
   margin: 0;
   font-size: 1.25rem;
@@ -166,6 +214,16 @@
   .chat-dock__header {
     padding: 0.5rem 0.7rem 0.3rem; /* reduzido */
     gap: 0.2rem;
+  }
+
+  .chat-dock__tabs {
+    padding: 0.6rem 1rem 0.35rem;
+    gap: 0.35rem;
+  }
+
+  .chat-dock__tab {
+    min-width: 140px;
+    padding: 0.45rem 0.75rem;
   }
 
   .chat-dock__history {

--- a/frontend/src/context/ChatContext.tsx
+++ b/frontend/src/context/ChatContext.tsx
@@ -5,48 +5,136 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState
 } from 'react';
 
-import type { ChatMessage } from '../types';
-import { fetchChatHistory, sendChatMessage } from '../services/chat';
+import type { ChatMessage, ChatSession } from '../types';
+import { fetchChatHistory, fetchChatSessions, sendChatMessage } from '../services/chat';
 import { useAuth } from './AuthContext';
 
 interface ChatContextValue {
   messages: ChatMessage[];
+  sessions: ChatSession[];
   isLoading: boolean;
   isSending: boolean;
   error?: string;
+  activeChatId?: string;
   sendMessage: (message: string, recipeId?: string) => Promise<void>;
   hydrate: () => Promise<void>;
+  startNewChat: () => void;
+  selectChat: (chatId?: string) => void;
 }
 
 const ChatContext = createContext<ChatContextValue | undefined>(undefined);
 
+const buildSessionTitle = (content?: string) => {
+  if (!content) {
+    return 'Nova conversa';
+  }
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return 'Nova conversa';
+  }
+  const maxLength = 60;
+  return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength)}…` : trimmed;
+};
+
 export const ChatProvider = ({ children }: { children: ReactNode }) => {
   const { session } = useAuth();
+  const token = session?.access_token;
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isSending, setIsSending] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
+  const [activeChatId, setActiveChatId] = useState<string | undefined>(undefined);
+  const fetchSequenceRef = useRef(0);
+
+  const resetState = useCallback(() => {
+    fetchSequenceRef.current += 1;
+    setMessages([]);
+    setSessions([]);
+    setActiveChatId(undefined);
+    setError(undefined);
+  }, []);
+
+  const loadMessagesForChat = useCallback(
+    async (chatId?: string, options: { showLoader?: boolean } = {}) => {
+      const { showLoader = true } = options;
+      const requestId = fetchSequenceRef.current + 1;
+      fetchSequenceRef.current = requestId;
+
+      if (!token || !chatId) {
+        setMessages([]);
+        setError(undefined);
+        if (showLoader) {
+          setIsLoading(false);
+        }
+        return;
+      }
+
+      if (showLoader) {
+        setIsLoading(true);
+      }
+
+      try {
+        const history = await fetchChatHistory(token, chatId);
+        if (fetchSequenceRef.current === requestId) {
+          setMessages(history);
+          setError(undefined);
+        }
+      } catch (err) {
+        if (fetchSequenceRef.current === requestId) {
+          console.error(err);
+          setError('Não foi possível carregar o histórico do chat.');
+        }
+      } finally {
+        if (fetchSequenceRef.current === requestId && showLoader) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [token]
+  );
 
   const hydrate = useCallback(async () => {
-    if (!session?.access_token) {
-      setMessages([]);
+    if (!token) {
+      resetState();
+      setIsLoading(false);
       return;
     }
     setIsLoading(true);
     try {
-      const history = await fetchChatHistory(session.access_token);
-      setMessages(history);
+      const sessionList = await fetchChatSessions(token);
+      setSessions(sessionList);
+
+      let resolvedChatId: string | undefined;
+      setActiveChatId((current) => {
+        if (current && sessionList.some((session) => session.id === current)) {
+          resolvedChatId = current;
+          return current;
+        }
+        resolvedChatId = sessionList[0]?.id;
+        return resolvedChatId;
+      });
+
+      if (!resolvedChatId) {
+        fetchSequenceRef.current += 1;
+        setMessages([]);
+      } else {
+        await loadMessagesForChat(resolvedChatId, { showLoader: false });
+      }
+
       setError(undefined);
     } catch (err) {
       console.error(err);
+      resetState();
       setError('Não foi possível carregar o histórico do chat.');
     } finally {
       setIsLoading(false);
     }
-  }, [session?.access_token]);
+  }, [loadMessagesForChat, resetState, token]);
 
   useEffect(() => {
     void hydrate();
@@ -54,7 +142,7 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
 
   const sendMessageHandler = useCallback(
     async (message: string, recipeId?: string) => {
-      if (!session?.access_token) {
+      if (!token) {
         return;
       }
 
@@ -62,14 +150,75 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
         id: `temp-${Date.now()}`,
         role: 'user',
         content: message,
-        createdAt: new Date().toISOString()
+        createdAt: new Date().toISOString(),
+        chatId: activeChatId ?? 'pending-chat'
       };
 
       setMessages((prev) => [...prev, optimisticMessage]);
       setIsSending(true);
       try {
-        const response = await sendChatMessage(session.access_token, { message, recipeId, threadId: optimisticMessage.id });
-        setMessages((prev) => [...prev.filter((msg) => msg.id !== optimisticMessage.id), optimisticMessage, response.message]);
+        const response = await sendChatMessage(token, {
+          message,
+          recipeId,
+          threadId: optimisticMessage.id,
+          chatId: activeChatId
+        });
+
+        const resolvedChatId = response.message.chatId;
+        setActiveChatId(resolvedChatId);
+
+        fetchSequenceRef.current += 1;
+
+        setMessages((prev) => {
+          const withoutOptimistic = prev.filter((msg) => msg.id !== optimisticMessage.id);
+          const serverUser = response.userMessage;
+          const fallbackUser: ChatMessage = {
+            ...optimisticMessage,
+            id: serverUser?.id ?? `user-${Date.now()}`,
+            chatId: resolvedChatId,
+            createdAt: serverUser?.createdAt ?? new Date().toISOString(),
+            content: serverUser?.content?.trim() ? serverUser.content : message,
+            role: 'user',
+            relatedRecipeIds: serverUser?.relatedRecipeIds,
+            suggestions: serverUser?.suggestions
+          };
+          const normalizedUser =
+            serverUser && serverUser.role === 'user' && serverUser.content?.trim()
+              ? { ...serverUser, chatId: resolvedChatId }
+              : fallbackUser;
+          return [...withoutOptimistic, normalizedUser, response.message];
+        });
+
+        setSessions((prev) => {
+          const existing = prev.find((sessionItem) => sessionItem.id === resolvedChatId);
+          const createdAt = existing?.createdAt ?? response.userMessage?.createdAt ?? optimisticMessage.createdAt;
+          const updatedAt = response.message?.createdAt ?? new Date().toISOString();
+          const messageCount = (existing?.messageCount ?? 0) + 2;
+          const titleSource = response.userMessage?.content ?? message;
+          const derivedTitle = existing?.title && existing.title !== 'Nova conversa'
+            ? existing.title
+            : buildSessionTitle(titleSource);
+
+          const updatedSession: ChatSession = {
+            id: resolvedChatId,
+            title: derivedTitle,
+            createdAt,
+            updatedAt,
+            messageCount
+          };
+
+          const others = prev.filter(
+            (sessionItem) =>
+              sessionItem.id !== resolvedChatId && (activeChatId ? sessionItem.id !== activeChatId : true)
+          );
+          const nextSessions = [updatedSession, ...others];
+          return nextSessions.sort(
+            (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+          );
+        });
+
+        await loadMessagesForChat(resolvedChatId, { showLoader: false });
+
         setError(undefined);
       } catch (err) {
         console.error(err);
@@ -79,12 +228,72 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
         setIsSending(false);
       }
     },
-    [session?.access_token]
+    [activeChatId, loadMessagesForChat, token]
+  );
+
+  const startNewChatHandler = useCallback(() => {
+    const newChatId = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : `chat-${Date.now()}`;
+    const nowIso = new Date().toISOString();
+    fetchSequenceRef.current += 1;
+    setActiveChatId(newChatId);
+    setMessages([]);
+    setSessions((prev) => {
+      const filtered = prev.filter((sessionItem) => sessionItem.id !== newChatId);
+      const placeholder: ChatSession = {
+        id: newChatId,
+        title: 'Nova conversa',
+        createdAt: nowIso,
+        updatedAt: nowIso,
+        messageCount: 0
+      };
+      return [placeholder, ...filtered];
+    });
+    setError(undefined);
+  }, []);
+
+  const selectChatHandler = useCallback(
+    (chatId?: string) => {
+      setActiveChatId((current) => {
+        if (current === chatId) {
+          return current;
+        }
+        return chatId;
+      });
+      if (chatId === activeChatId) {
+        return;
+      }
+      void loadMessagesForChat(chatId);
+    },
+    [activeChatId, loadMessagesForChat]
   );
 
   const value = useMemo(
-    () => ({ messages, isLoading, isSending, error, sendMessage: sendMessageHandler, hydrate }),
-    [error, hydrate, isLoading, isSending, messages, sendMessageHandler]
+    () => ({
+      messages,
+      sessions,
+      isLoading,
+      isSending,
+      error,
+      activeChatId,
+      sendMessage: sendMessageHandler,
+      hydrate,
+      startNewChat: startNewChatHandler,
+      selectChat: selectChatHandler
+    }),
+    [
+      activeChatId,
+      error,
+      hydrate,
+      isLoading,
+      isSending,
+      messages,
+      selectChatHandler,
+      sendMessageHandler,
+      sessions,
+      startNewChatHandler
+    ]
   );
 
   return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;

--- a/frontend/src/services/chat.ts
+++ b/frontend/src/services/chat.ts
@@ -1,27 +1,39 @@
 import { apiRequest } from './api';
-import type { ChatMessage } from '../types';
+import type { ChatMessage, ChatSession } from '../types';
 
 export interface ChatRequestPayload {
   message: string;
   recipeId?: string;
   threadId?: string;
+  chatId?: string;
 }
 
 export interface ChatResponse {
   message: ChatMessage;
+  userMessage: ChatMessage;
   relatedRecipes?: string[];
   followUpPrompts?: Array<{ label: string; prompt: string }>;
 }
 
-export const sendChatMessage = (token: string, payload: ChatRequestPayload) =>
-  apiRequest<ChatResponse>('/chat', {
+export const sendChatMessage = (token: string, payload: ChatRequestPayload) => {
+  return apiRequest<ChatResponse>('/chat', {
     method: 'POST',
     authToken: token,
     body: JSON.stringify(payload)
   });
+};
 
-export const fetchChatHistory = (token: string) =>
-  apiRequest<ChatMessage[]>('/chat/history', {
+export const fetchChatHistory = (token: string, chatId?: string) => {
+  const query = chatId ? `?chatId=${encodeURIComponent(chatId)}` : '';
+  return apiRequest<ChatMessage[]>(`/chat/history${query}`, {
     method: 'GET',
     authToken: token
   });
+};
+
+export const fetchChatSessions = (token: string) => {
+  return apiRequest<ChatSession[]>('/chat/sessions', {
+    method: 'GET',
+    authToken: token
+  });
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -62,8 +62,17 @@ export interface ChatMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
   createdAt: string;
+  chatId: string;
   relatedRecipeIds?: string[];
   suggestions?: Array<{ label: string; prompt: string }>;
+}
+
+export interface ChatSession {
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  messageCount: number;
 }
 
 export interface ImportResult {

--- a/src/app/routers/chat.py
+++ b/src/app/routers/chat.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from supabase import Client
 
 from src.app.deps import CurrentUser, get_current_user, get_supabase
-from src.app.schemas.chat import ChatMessage, ChatRequest, ChatResponse
+from src.app.schemas.chat import (
+    ChatMessage,
+    ChatRequest,
+    ChatResponse,
+    ChatSession,
+)
 from src.services import chat_store
 
 router = APIRouter(prefix="/chat", tags=["chat"])
@@ -12,11 +17,26 @@ router = APIRouter(prefix="/chat", tags=["chat"])
 
 @router.get("/history", response_model=list[ChatMessage])
 async def get_history(
+    chat_id: str | None = Query(default=None, alias="chatId"),
     user: CurrentUser = Depends(get_current_user),
     supa: Client = Depends(get_supabase),
 ) -> list[ChatMessage]:
-    return [ChatMessage(**msg) for msg in chat_store.list_messages(str(user.id), supa)]
+    return [
+        ChatMessage(**msg)
+        for msg in chat_store.list_messages(str(user.id), supa, chat_id=chat_id)
+    ]
 
+
+
+@router.get("/sessions", response_model=list[ChatSession])
+async def list_sessions(
+    user: CurrentUser = Depends(get_current_user),
+    supa: Client = Depends(get_supabase),
+) -> list[ChatSession]:
+    return [
+        ChatSession(**session)
+        for session in chat_store.list_sessions(str(user.id), supa)
+    ]
 
 
 @router.post("/", response_model=ChatResponse)
@@ -26,14 +46,18 @@ async def post_message(
     supa: Client = Depends(get_supabase),
 ) -> ChatResponse:
     try:
-        assistant_msg = chat_store.send_message(
+        chat_result = chat_store.send_message(
             user=user,
             supa=supa,
             message=payload.message,
             recipe_id=payload.recipeId,
             client_message_id=payload.threadId,
+            chat_id=payload.chatId,
         )
-        return ChatResponse(message=ChatMessage(**assistant_msg))
+        return ChatResponse(
+            message=ChatMessage(**chat_result["assistant"]),
+            userMessage=ChatMessage(**chat_result["user"]),
+        )
     except Exception as exc:
         # Log do erro pode ser adicionado aqui se necessário
         raise HTTPException(

--- a/src/app/schemas/chat.py
+++ b/src/app/schemas/chat.py
@@ -11,6 +11,7 @@ class ChatMessage(BaseModel):
     role: Literal["user", "assistant", "system"]
     content: str
     createdAt: datetime
+    chatId: str
     relatedRecipeIds: Optional[list[str]] = None
     suggestions: Optional[list[dict[str, str]]] = None
 
@@ -19,8 +20,18 @@ class ChatRequest(BaseModel):
     message: str = Field(..., min_length=1)
     recipeId: Optional[str] = None
     threadId: Optional[str] = None
+    chatId: Optional[str] = None
 
 
 class ChatResponse(BaseModel):
     message: ChatMessage
+    userMessage: ChatMessage
+
+
+class ChatSession(BaseModel):
+    id: str
+    title: str
+    createdAt: datetime
+    updatedAt: datetime
+    messageCount: int
 


### PR DESCRIPTION
## Summary
- sanitize chat client state updates so user messages persist locally, tabs stay in sync, and the latest history is reloaded after each send
- harden Supabase chat persistence to retry inserts when optional columns are missing or chat ids are malformed, and fall back to local records if all attempts fail

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68de01a216a48323b605cbabc73d8789