### PR TITLE
Add chat modal component to restore TopBar import

### DIFF
--- a/frontend/src/components/chat/ChatModal.tsx
+++ b/frontend/src/components/chat/ChatModal.tsx
@@ -1,0 +1,49 @@
+import { type MouseEvent, useEffect } from 'react';
+
+import ChatDock from './ChatDock';
+import './chat.css';
+
+type ChatModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  initialPrompt?: string;
+};
+
+export function ChatModal({ isOpen, onClose, initialPrompt }: ChatModalProps) {
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div className="chat-modal" role="dialog" aria-modal="true" aria-label="Assistente de receitas">
+      <div className="chat-modal__backdrop" onClick={handleBackdropClick} />
+      <div className="chat-modal__content">
+        <button type="button" className="chat-modal__close" onClick={onClose} aria-label="Fechar assistente">
+          <span aria-hidden="true">×</span>
+        </button>
+        <ChatDock initialPrompt={initialPrompt} />
+      </div>
+    </div>
+  );
+}
+
+export default ChatModal;

--- a/frontend/src/components/chat/chat.css
+++ b/frontend/src/components/chat/chat.css
@@ -1,3 +1,59 @@
+.chat-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.chat-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(17, 18, 20, 0.65);
+  backdrop-filter: blur(6px);
+}
+
+.chat-modal__content {
+  position: relative;
+  width: min(960px, 96vw);
+  height: min(720px, 90vh);
+  display: flex;
+  flex-direction: column;
+  border-radius: clamp(1.4rem, 3vw, 1.8rem);
+  overflow: hidden;
+  box-shadow: var(--shadow-lg, 0 24px 56px rgba(15, 23, 42, 0.35));
+}
+
+.chat-modal__close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.85rem;
+  border: none;
+  background: rgba(17, 18, 20, 0.48);
+  color: #fff;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+  z-index: 1;
+}
+
+.chat-modal__close:hover {
+  transform: scale(1.05);
+  background: rgba(17, 18, 20, 0.65);
+}
+
+.chat-modal__close:active {
+  transform: scale(0.95);
+}
+
 .chat-dock {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a ChatModal component that wraps ChatDock in an accessible modal shell
- style the modal overlay and close button within the existing chat stylesheet

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de1dde6b0883239b225d1dfac742c1