### PR TITLE
Improve TopBar responsiveness and chat entrypoint

### DIFF
--- a/frontend/src/components/chat/ChatModal.tsx
+++ b/frontend/src/components/chat/ChatModal.tsx
@@ -1,0 +1,49 @@
+import { type MouseEvent, useEffect } from 'react';
+
+import ChatDock from './ChatDock';
+import './chat.css';
+
+type ChatModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  initialPrompt?: string;
+};
+
+export function ChatModal({ isOpen, onClose, initialPrompt }: ChatModalProps) {
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div className="chat-modal" role="dialog" aria-modal="true" aria-label="Assistente de receitas">
+      <div className="chat-modal__backdrop" onClick={handleBackdropClick} />
+      <div className="chat-modal__content">
+        <button type="button" className="chat-modal__close" onClick={onClose} aria-label="Fechar assistente">
+          <span aria-hidden="true">×</span>
+        </button>
+        <ChatDock initialPrompt={initialPrompt} />
+      </div>
+    </div>
+  );
+}
+
+export default ChatModal;

--- a/frontend/src/components/chat/chat.css
+++ b/frontend/src/components/chat/chat.css
@@ -1,3 +1,59 @@
+.chat-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.chat-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(17, 18, 20, 0.65);
+  backdrop-filter: blur(6px);
+}
+
+.chat-modal__content {
+  position: relative;
+  width: min(960px, 96vw);
+  height: min(720px, 90vh);
+  display: flex;
+  flex-direction: column;
+  border-radius: clamp(1.4rem, 3vw, 1.8rem);
+  overflow: hidden;
+  box-shadow: var(--shadow-lg, 0 24px 56px rgba(15, 23, 42, 0.35));
+}
+
+.chat-modal__close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.85rem;
+  border: none;
+  background: rgba(17, 18, 20, 0.48);
+  color: #fff;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+  z-index: 1;
+}
+
+.chat-modal__close:hover {
+  transform: scale(1.05);
+  background: rgba(17, 18, 20, 0.65);
+}
+
+.chat-modal__close:active {
+  transform: scale(0.95);
+}
+
 .chat-dock {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -1,13 +1,12 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Bell, ChefHat, Moon, Search, Sun } from 'lucide-react';
+import { Bell, ChefHat, MessageCircle, Moon, Search, Sun } from 'lucide-react';
 
 import { SearchDropdown } from './SearchDropdown';
 import { useRecipes } from '../../context/RecipeContext';
 import type { Recipe } from '../../types';
 import { useAuth } from '../../context/AuthContext';
 import { useTheme } from '../../context/ThemeContext';
-import { useChat } from '../../context/ChatContext';
 import { ChatModal } from '../chat/ChatModal';
 
 import './layout.css';
@@ -37,7 +36,6 @@ const TopBar = ({ forceCondensed }: TopBarProps) => {
   const { recipes, isLoading } = useRecipes();
   const { user } = useAuth();
   const { theme, toggleTheme } = useTheme();
-  const { sendMessage } = useChat();
   const [showDropdown, setShowDropdown] = useState(false);
   const [showChatModal, setShowChatModal] = useState(false);
   const [query, setQuery] = useState(() => {
@@ -127,15 +125,77 @@ const TopBar = ({ forceCondensed }: TopBarProps) => {
         <div className="search-dropdown-backdrop" aria-hidden="true" />
       ) : null}
       <div className="topbar__glass">
-        <button type="button" className="topbar__brand" onClick={handleGoHome} aria-label="Ir para a pgina inicial">
-          <span className="topbar__brand-icon">
-            <ChefHat size={18} />
-          </span>
-          <span className="topbar__brand-text">
-            <span className="topbar__brand-eyebrow">Chef IA</span>
-            <span className="topbar__brand-title">Cozinha viva</span>
-          </span>
-        </button>
+        <div className="topbar__header">
+          <button type="button" className="topbar__brand" onClick={handleGoHome} aria-label="Ir para a pgina inicial">
+            <span className="topbar__brand-icon">
+              <ChefHat size={18} />
+            </span>
+            <span className="topbar__brand-text">
+              <span className="topbar__brand-eyebrow">Chef IA</span>
+              <span className="topbar__brand-title">Cozinha viva</span>
+            </span>
+          </button>
+
+          <div className="topbar__header-actions">
+            <div className="topbar__actions">
+              <button
+                type="button"
+                className="topbar__action topbar__action--highlight"
+                onClick={() => setShowChatModal(true)}
+                aria-label="Abrir o assistente Chef IA"
+              >
+                <MessageCircle size={18} />
+                <span>Chef IA</span>
+              </button>
+              <button
+                type="button"
+                className="topbar__action topbar__action--ghost"
+                onClick={toggleTheme}
+                aria-label={themeLabel}
+                title={themeLabel}
+              >
+                {themeIsDark ? <Sun size={18} /> : <Moon size={18} />}
+              </button>
+              <button
+                type="button"
+                className="topbar__action topbar__action--ghost"
+                aria-label="Notificaes em breve"
+                title="Notificaes em breve"
+                disabled
+              >
+                <Bell size={18} />
+              </button>
+            </div>
+            <button
+              type="button"
+              className="topbar__profile"
+              onClick={handleProfile}
+              aria-label="Abrir perfil"
+            >
+              {user?.avatarUrl ? (
+                <img src={user.avatarUrl} alt="" className="topbar__avatar" />
+              ) : (
+                <span className="topbar__avatar">{userInitials}</span>
+              )}
+              <span className="topbar__profile-info">
+                <span className="topbar__profile-greeting">{greeting}</span>
+                <span className="topbar__profile-meta">Minha conta</span>
+              </span>
+            </button>
+            <button
+              type="button"
+              className="topbar__profile-badge"
+              onClick={handleProfile}
+              aria-label="Abrir perfil"
+            >
+              {user?.avatarUrl ? (
+                <img src={user.avatarUrl} alt="" className="topbar__profile-badge-img" />
+              ) : (
+                <span aria-hidden="true">{userInitials}</span>
+              )}
+            </button>
+          </div>
+        </div>
 
         <div className="topbar__center" role="search" ref={searchAreaRef}>
           <span className="topbar__center-eyebrow">{subheadline}</span>
@@ -175,37 +235,6 @@ const TopBar = ({ forceCondensed }: TopBarProps) => {
           ) : null}
         </div>
 
-        <div className="topbar__actions">
-          <button
-            type="button"
-            className="topbar__action topbar__action--ghost"
-            onClick={toggleTheme}
-            aria-label={themeLabel}
-            title={themeLabel}
-          >
-            {themeIsDark ? <Sun size={18} /> : <Moon size={18} />}
-          </button>
-          <button
-            type="button"
-            className="topbar__action topbar__action--ghost"
-            aria-label="Notificaes em breve"
-            title="Notificaes em breve"
-            disabled
-          >
-            <Bell size={18} />
-          </button>
-          <button type="button" className="topbar__profile" onClick={handleProfile} aria-label="Abrir perfil">
-            {user?.avatarUrl ? (
-              <img src={user.avatarUrl} alt="" className="topbar__avatar" />
-            ) : (
-              <span className="topbar__avatar">{userInitials}</span>
-            )}
-            <span className="topbar__profile-info">
-              <span className="topbar__profile-greeting">{greeting}</span>
-              <span className="topbar__profile-meta">Minha conta</span>
-            </span>
-          </button>
-        </div>
       </div>
       <ChatModal isOpen={showChatModal} onClose={() => setShowChatModal(false)} />
     </header>

--- a/frontend/src/components/layout/layout.css
+++ b/frontend/src/components/layout/layout.css
@@ -136,9 +136,9 @@ body.chat-focus .app-shell {
 .topbar__glass {
   position: relative;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: clamp(1rem, 3vw, 2rem);
+  flex-direction: column;
+  align-items: stretch;
+  gap: clamp(1.05rem, 2.8vw, 1.85rem);
   width: 100%;
   padding: clamp(0.95rem, 2.4vw, 1.55rem) clamp(1.4rem, 3.6vw, 2.5rem);
   border-radius: clamp(1.6rem, 3.6vw, 2.4rem);
@@ -149,6 +149,22 @@ body.chat-focus .app-shell {
   -webkit-backdrop-filter: blur(28px) saturate(170%);
   overflow: visible;
   z-index: 160;
+}
+
+.topbar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(0.85rem, 2.2vw, 1.35rem);
+  width: 100%;
+}
+
+.topbar__header-actions {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.65rem, 2vw, 1.1rem);
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .search-dropdown-backdrop {
@@ -275,9 +291,9 @@ body.chat-focus .app-shell {
 }
 
 .topbar__actions {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: clamp(0.55rem, 2vw, 0.95rem);
+  gap: clamp(0.5rem, 1.8vw, 0.9rem);
   flex-shrink: 0;
 }
 
@@ -293,6 +309,19 @@ body.chat-focus .app-shell {
   color: var(--color-muted);
   font-weight: 600;
   transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.25s ease;
+}
+
+.topbar__action--highlight {
+  border: none;
+  background: var(--gradient-brand);
+  color: #fff;
+  padding: 0.62rem 1.05rem;
+  box-shadow: 0 20px 42px -26px rgba(232, 93, 4, 0.5);
+}
+
+.topbar__action--highlight:hover,
+.topbar__action--highlight:focus-visible {
+  background: linear-gradient(135deg, rgba(232, 93, 4, 0.95), rgba(255, 159, 28, 0.78));
 }
 
 .topbar__action svg {
@@ -395,6 +424,56 @@ body.chat-focus .app-shell {
 
 :root[data-theme='dark'] .topbar__profile-meta {
   color: rgba(236, 240, 247, 0.68);
+}
+
+.topbar__profile-badge {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--color-heading);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 0 16px 32px -24px rgba(12, 18, 28, 0.5);
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.25s ease;
+  padding: 0;
+  overflow: hidden;
+}
+
+.topbar__profile-badge:hover,
+.topbar__profile-badge:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.22);
+  box-shadow: 0 20px 36px -26px rgba(12, 18, 28, 0.6);
+}
+
+.topbar__profile-badge:focus-visible {
+  outline: 2px solid rgba(232, 93, 4, 0.45);
+  outline-offset: 2px;
+}
+
+.topbar__profile-badge span {
+  line-height: 1;
+}
+
+:root[data-theme='dark'] .topbar__profile-badge {
+  border-color: rgba(236, 240, 247, 0.2);
+  background: rgba(236, 240, 247, 0.12);
+  color: rgba(236, 240, 247, 0.94);
+}
+
+.topbar__profile-badge-img {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  object-fit: cover;
+  border: 1px solid rgba(255, 255, 255, 0.18);
 }
 
 
@@ -564,34 +643,6 @@ body.chat-focus .app-shell {
 }
 
 @media (max-width: 1180px) {
-  .topbar__glass {
-    flex-wrap: wrap;
-    align-items: flex-start;
-    gap: clamp(0.75rem, 2.2vw, 1.35rem);
-  }
-
-  .topbar__brand {
-    flex: 0 0 auto;
-    margin-right: auto;
-  }
-
-  .topbar__actions {
-    order: 2;
-    flex: 1 1 100%;
-    justify-content: flex-end;
-    flex-wrap: wrap;
-    gap: clamp(0.35rem, 1.8vw, 0.7rem);
-  }
-
-  .topbar__center {
-    order: 3;
-    width: 100%;
-  }
-
-  .topbar__search {
-    margin-top: clamp(0.35rem, 1vw, 0.55rem);
-  }
-
   .topbar__profile-info {
     display: none;
   }
@@ -606,145 +657,112 @@ body.chat-focus .app-shell {
     padding: 0.45rem 0.6rem;
   }
 
-  .topbar__actions {
-    justify-content: space-between;
+  .topbar__header-actions {
+    gap: clamp(0.45rem, 1.8vw, 0.75rem);
   }
 }
 
 @media (max-width: 720px) {
-
   .topbar {
-
     padding: clamp(0.9rem, 4vw, 1.3rem) clamp(0.85rem, 6vw, 1.5rem) 0;
-
   }
 
-
-
-  .topbar__glass {
-
-    border-radius: var(--radius-xl);
-
-    width: 100%;
-
+  .topbar__header {
     flex-direction: column;
-
     align-items: stretch;
-
-    gap: clamp(0.85rem, 4vw, 1.3rem);
-
+    gap: clamp(0.85rem, 3.8vw, 1.2rem);
   }
-
-
 
   .topbar__brand {
-
     width: 100%;
-
     justify-content: space-between;
-
     padding: 0.45rem 0.9rem;
-
   }
 
-
-
-  .topbar__center {
-
+  .topbar__header-actions {
     width: 100%;
-
+    justify-content: space-between;
   }
-
-
-
-  .topbar__center-eyebrow {
-
-    font-size: 0.68rem;
-
-    letter-spacing: 0.28em;
-
-  }
-
-
-
-  .topbar__search {
-
-    flex-direction: column;
-
-    align-items: stretch;
-
-    gap: 0.75rem;
-
-  }
-
-
 
   .topbar__actions {
-
-    width: 100%;
-
-    flex-wrap: wrap;
-
-    justify-content: space-between;
-
-    gap: 0.75rem;
-
+    flex: 1 1 auto;
+    justify-content: flex-start;
   }
-
-
-
-  .topbar__action--highlight {
-
-    flex: 1 1 100%;
-
-    justify-content: center;
-
-  }
-
-
 
   .topbar__profile {
-
-    flex: 1 1 100%;
-
-    justify-content: space-between;
-
-    padding: 0.45rem 0.8rem;
-
+    display: none;
   }
 
+  .topbar__profile-badge {
+    display: inline-flex;
+  }
 
-
-  .topbar__profile-info {
-
-    flex-direction: row;
-
-    align-items: center;
-
-    justify-content: space-between;
-
+  .topbar__center {
     width: 100%;
-
   }
 
+  .topbar__center-eyebrow {
+    font-size: 0.68rem;
+    letter-spacing: 0.28em;
+  }
 
+  .topbar__search {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
 
   .topbar__search-actions {
-
-    justify-content: flex-end;
-
+    justify-content: space-between;
+    width: 100%;
   }
 
+  .topbar__search-actions button {
+    flex: 1 1 100%;
+  }
 
+  .topbar__clear {
+    justify-content: center;
+    display: inline-flex;
+    align-items: center;
+  }
 
   .topbar__search-button {
-
     width: 100%;
-
   }
-
 }
 
+@media (max-width: 540px) {
+  .topbar__actions {
+    gap: 0.5rem;
+  }
+
+  .topbar__action {
+    flex: 1 1 auto;
+  }
+
+  .topbar__action span {
+    display: none;
+  }
+
+  .topbar__action--highlight {
+    min-width: 2.8rem;
+    padding: 0.6rem;
+  }
+
+  .topbar__search {
+    padding: clamp(0.55rem, 2vw, 0.7rem) clamp(0.65rem, 4vw, 0.95rem);
+  }
+
+  .topbar__search-actions {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .topbar__search-actions button {
+    width: 100%;
+  }
+}
 .bottom-nav {
   position: fixed;
   left: 0;


### PR DESCRIPTION
## Summary
- restructure the TopBar markup to group the brand, utility actions, and profile controls for better small-screen flow
- add a highlighted chat assistant button plus a compact avatar badge that replaces the profile card on narrow viewports
- refresh the layout stylesheet with new header, action, and media-query rules tuned for responsive behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de1dde6b0883239b225d1dfac742c1