### PR TITLE
Limit bottom nav width on larger screens

### DIFF
--- a/frontend/src/components/layout/layout.css
+++ b/frontend/src/components/layout/layout.css
@@ -894,6 +894,7 @@ body.chat-focus .app-shell {
   align-items: end;
   min-height: 3.5rem;
   width: 100%;
+  max-width: 34rem;
   margin: 0 auto;
   padding: 0.4rem var(--space-4);
   border-radius: var(--radius-lg);
@@ -1052,6 +1053,7 @@ body.chat-focus .app-shell {
 
   .bottom-nav__inner {
     width: 100%;
+    max-width: 38rem;
     padding: 0.5rem var(--space-6);
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-soft);


### PR DESCRIPTION
## Summary
- cap the bottom navigation container width to avoid overstretching on wide viewports
- provide a slightly larger maximum width on desktop while keeping the bar centered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e05cec47cc8323ba93e378b815219c