### PR TITLE
Implement paginated recipe search flow

### DIFF
--- a/frontend/src/components/layout/search-dropdown.css
+++ b/frontend/src/components/layout/search-dropdown.css
@@ -188,6 +188,28 @@
   padding-top: 0.4rem;
 }
 
+.search-dropdown__load-more {
+  margin-top: 0.35rem;
+  padding: 0.45rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: transparent;
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.search-dropdown__load-more:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.search-dropdown__load-more:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .search-dropdown__section--recipes .search-dropdown__heading {
   color: var(--color-primary);
 }

--- a/frontend/src/services/recipes.ts
+++ b/frontend/src/services/recipes.ts
@@ -1,15 +1,37 @@
 import { apiRequest } from './api';
-import type { ImportResult, Recipe } from '../types';
+import type { ImportResult, Recipe, RecipeListResponse } from '../types';
 
 export interface RecipePayload extends Partial<Recipe> {
   title: string;
 }
 
-export const fetchRecipes = (token: string) =>
-  apiRequest<Recipe[]>('/recipes', {
+export interface FetchRecipesOptions {
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export const fetchRecipes = (token: string, options: FetchRecipesOptions = {}) => {
+  const params = new URLSearchParams();
+  const searchTerm = options.search?.trim();
+  if (searchTerm) {
+    params.set('q', searchTerm);
+  }
+  if (typeof options.limit === 'number') {
+    params.set('limit', String(options.limit));
+  }
+  if (typeof options.offset === 'number') {
+    params.set('offset', String(options.offset));
+  }
+
+  const queryString = params.toString();
+  const path = queryString ? `/recipes?${queryString}` : '/recipes';
+
+  return apiRequest<RecipeListResponse>(path, {
     method: 'GET',
     authToken: token
   });
+};
 
 export const fetchRecipe = (token: string, recipeId: string) =>
   apiRequest<Recipe>(`/recipes/${recipeId}`, {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -57,6 +57,13 @@ export interface Recipe {
   updatedAt?: string;
 }
 
+export interface RecipeListResponse {
+  items: Recipe[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export interface ChatMessage {
   id: string;
   role: 'user' | 'assistant' | 'system';

--- a/src/app/schemas/ingest.py
+++ b/src/app/schemas/ingest.py
@@ -50,6 +50,13 @@ class RecipeResponse(BaseModel):
     updatedAt: Optional[str] = None
 
 
+class RecipeListResponse(BaseModel):
+    items: list[RecipeResponse]
+    total: int
+    limit: int
+    offset: int
+
+
 class IngestResponse(BaseModel):
     recipe: RecipeResponse
     warnings: Optional[list[str]] = None


### PR DESCRIPTION
## Summary
- extend the `/recipes` endpoint to support server-side search and pagination metadata
- update the Supabase client and React context to fetch paginated search results with debounced queries
- refresh the top bar dropdown to render backend-filtered matches and allow loading additional pages

## Testing
- npm --prefix frontend run build


------
https://chatgpt.com/codex/tasks/task_e_68e052d864cc832394fcf6fbaffeb5ca