### PR TITLE
feat: redesign timeline carousel cards

### DIFF
--- a/frontend/src/pages/home.css
+++ b/frontend/src/pages/home.css
@@ -126,41 +126,104 @@
 .timeline__carousel-card {
   position: relative;
   width: 100%;
-  aspect-ratio: 4 / 3;
+  aspect-ratio: 16 / 9;
   min-height: 0;
   border-radius: clamp(1.4rem, 3vw, 2rem);
-  background-size: cover;
-  background-position: center;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  padding: clamp(0.9rem, 2.4vw, 1.2rem);
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  gap: var(--space-3);
-  text-align: left;
-  color: #fff;
   overflow: hidden;
-  box-shadow: var(--shadow-soft);
+  border: none;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.14), var(--shadow-soft);
+  background: #050a11;
+  color: #fff;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: clamp(1rem, 2.6vw, 1.5rem);
+  text-align: left;
   cursor: pointer;
+  transition: transform 0.28s ease, box-shadow 0.28s ease;
+  font: inherit;
+  line-height: inherit;
+}
+
+.timeline__carousel-card:focus {
+  outline: none;
+}
+
+.timeline__carousel-card:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 3px;
+}
+
+.timeline__carousel-card:hover {
+  transform: scale(1.02);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2), 0 20px 44px rgba(6, 10, 18, 0.35);
+}
+
+.timeline__carousel-card:hover .timeline__carousel-card-image {
+  transform: scale(1.05);
+}
+
+@media (max-width: 640px) {
+  .timeline__carousel-card {
+    aspect-ratio: 4 / 5;
+    padding: clamp(1rem, 5vw, 1.4rem);
+  }
+}
+
+.timeline__carousel-card-media {
+  position: absolute;
+  inset: 0;
+  display: block;
+  overflow: hidden;
+  pointer-events: none;
+  background: #111;
+}
+
+.timeline__carousel-card-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.6s ease;
+  filter: saturate(1.08);
 }
 
 .timeline__carousel-card-overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(18, 22, 30, 0) 35%, rgba(18, 22, 30, 0.82) 100%);
-  z-index: 0;
-}
-
-.timeline__carousel-card-title,
-.timeline__carousel-card-meta {
-  position: relative;
+  background: linear-gradient(180deg, rgba(5, 8, 15, 0) 40%, rgba(5, 8, 15, 0.8) 100%);
+  pointer-events: none;
   z-index: 1;
 }
 
-.timeline__carousel-card-title {
-  font-size: 1rem;
+.timeline__carousel-card-body {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  gap: clamp(0.45rem, 1.5vw, 0.75rem);
+  width: 100%;
+}
+
+.timeline__carousel-card-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.7);
+  color: rgba(255, 255, 255, 0.95);
+  font-size: clamp(0.75rem, 1.6vw, 0.88rem);
   font-weight: 700;
-  line-height: 1.4;
+  letter-spacing: 0.05em;
+  backdrop-filter: blur(4px);
+  max-width: 100%;
+}
+
+.timeline__carousel-card-title {
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  margin: 0;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -168,44 +231,123 @@
 }
 
 .timeline__carousel-card-meta {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  font-size: 0.82rem;
-  font-weight: 600;
-  padding: 0.25rem 0.75rem;
+  font-size: clamp(0.75rem, 1.5vw, 0.81rem);
+  color: rgba(255, 255, 255, 0.85);
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+}
+
+.timeline__carousel-card.is-placeholder .timeline__carousel-card-media {
+  background: linear-gradient(135deg, rgba(232, 93, 4, 0.35), rgba(70, 106, 255, 0.38));
+}
+
+.timeline__carousel-card.is-placeholder .timeline__carousel-card-image {
+  opacity: 0;
+}
+
+.timeline__carousel-card.is-loading {
+  pointer-events: none;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  background: linear-gradient(135deg, rgba(9, 15, 24, 0.92), rgba(22, 32, 48, 0.92));
+  animation: shimmerPulse 2.4s ease-in-out infinite;
+}
+
+.timeline__carousel-card.is-loading .timeline__carousel-card-media,
+.timeline__carousel-card.is-loading .timeline__carousel-card-overlay {
+  display: none;
+}
+
+.timeline__carousel-card.is-loading .timeline__carousel-card-body {
+  gap: 0.8rem;
+}
+
+.timeline__carousel-card-line {
+  display: block;
+  width: 75%;
+  height: 0.8rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.18);
-  color: rgba(255, 255, 255, 0.9);
-  align-self: flex-start;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.06) 0%,
+    rgba(255, 255, 255, 0.18) 50%,
+    rgba(255, 255, 255, 0.06) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmerSlide 1.8s ease-in-out infinite;
+}
+
+.timeline__carousel-card-line.short {
+  width: 45%;
+}
+
+.timeline__carousel-card.is-loading .timeline__carousel-card-line {
+  animation-duration: 2.2s;
 }
 
 .timeline__carousel-favorite {
   position: absolute;
-  top: 1.1rem;
-  right: 1.1rem;
+  top: 0.9rem;
+  right: 0.9rem;
   width: 44px;
   height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.45);
-  background: rgba(17, 20, 28, 0.45);
-  color: rgba(255, 255, 255, 0.82);
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.92);
   display: grid;
   place-items: center;
   cursor: pointer;
-  transition: transform 0.25s ease, background 0.25s ease, color 0.25s ease;
+  transition: transform 0.25s ease, background 0.25s ease, color 0.25s ease, border-color 0.25s ease;
+  backdrop-filter: blur(8px);
+}
+
+@supports not (backdrop-filter: blur(8px)) {
+  .timeline__carousel-favorite {
+    background: rgba(0, 0, 0, 0.72);
+  }
 }
 
 .timeline__carousel-favorite:hover {
-  transform: translateY(-3px);
-  background: rgba(232, 93, 4, 0.4);
+  transform: translateY(-2px) scale(1.05);
+  background: rgba(232, 93, 4, 0.7);
   color: #fff;
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.timeline__carousel-favorite:focus {
+  outline: none;
+}
+
+.timeline__carousel-favorite:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
 }
 
 .timeline__carousel-favorite.is-active {
   background: rgba(232, 93, 4, 0.9);
-  border-color: rgba(255, 255, 255, 0.65);
+  border-color: rgba(255, 255, 255, 0.4);
   color: #fff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .timeline__carousel-card,
+  .timeline__carousel-card-image,
+  .timeline__carousel-favorite {
+    transition: none;
+  }
+
+  .timeline__carousel-card:hover {
+    transform: none;
+  }
+
+  .timeline__carousel-card-line,
+  .timeline__carousel-card.is-loading .timeline__carousel-card-line {
+    animation-duration: 3.2s;
+  }
 }
 
 .timeline__feed {
@@ -237,6 +379,27 @@
   margin: 0;
   color: var(--color-muted);
   font-weight: 500;
+}
+
+@keyframes shimmerSlide {
+  0% {
+    background-position: -200% 0;
+  }
+
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+@keyframes shimmerPulse {
+  0%,
+  100% {
+    opacity: 0.92;
+  }
+
+  50% {
+    opacity: 1;
+  }
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- refactor the timeline carousel card to use responsive images, heuristics for object position, and accessible favorite controls with loading and fallback states
- refresh the carousel card styling with new gradient overlays, chips, skeleton shimmer, and mobile aspect ratio adjustments while preserving focus behavior

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e34149766c832390a8a272a616a458