### PR TITLE
Revamp home import entry and favorite styling

### DIFF
--- a/frontend/src/components/recipes/RecipeCard.tsx
+++ b/frontend/src/components/recipes/RecipeCard.tsx
@@ -46,7 +46,15 @@ const RecipeCard = ({ recipe, onOpen, onToggleFavorite }: RecipeCardProps) => {
         aria-pressed={recipe.isFavorite}
         aria-label={recipe.isFavorite ? 'Remover dos favoritos' : 'Adicionar aos favoritos'}
       >
-        <span aria-hidden="true">★</span>
+        <span aria-hidden="true" className="recipe-card__favorite-icon">
+          <svg viewBox="0 0 24 24" focusable="false">
+            <path
+              d="M12 5a3.5 3.5 0 0 0-3.5 3.5V10H7a5 5 0 0 0-5 5v1.5A1.5 1.5 0 0 0 3.5 18H20.5A1.5 1.5 0 0 0 22 16.5V15a5 5 0 0 0-5-5h-1.5V8.5A3.5 3.5 0 0 0 12 5Zm0 2a1.5 1.5 0 0 1 1.5 1.5V10h-3V8.5A1.5 1.5 0 0 1 12 7Zm9 10H3v1a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1Z"
+              fill="currentColor"
+              stroke="none"
+            />
+          </svg>
+        </span>
       </button>
 
       <div className="recipe-card__body">

--- a/frontend/src/components/recipes/recipes.css
+++ b/frontend/src/components/recipes/recipes.css
@@ -37,31 +37,49 @@
 
 .recipe-card__favorite {
   position: absolute;
-  top: 1.3rem;
-  right: 1.3rem;
-  width: 48px;
-  height: 48px;
-  border-radius: 18px;
-  border: 1px solid var(--color-border);
-  background: rgba(255, 255, 255, 0.92);
-  color: var(--color-muted);
+  top: 0.85rem;
+  right: 0.85rem;
+  width: 52px;
+  height: 52px;
+  border-radius: 20px;
+  border: 1px solid rgba(232, 93, 4, 0.28);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.85), rgba(255, 232, 214, 0.7));
+  color: rgba(215, 72, 15, 0.85);
   display: grid;
   place-items: center;
   cursor: pointer;
-  box-shadow: 0 22px 46px -30px rgba(18, 24, 42, 0.4);
-  transition: transform 0.25s ease, background 0.25s ease, color 0.25s ease;
+  box-shadow: 0 26px 52px -32px rgba(18, 24, 42, 0.5);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  transition:
+    transform 0.25s ease,
+    background 0.25s ease,
+    color 0.25s ease,
+    box-shadow 0.25s ease;
 }
 
 .recipe-card__favorite:hover {
-  transform: translateY(-3px);
-  background: rgba(232, 93, 4, 0.16);
-  color: var(--color-primary);
+  transform: translateY(-3px) scale(1.02);
+  background: linear-gradient(145deg, rgba(255, 240, 228, 0.95), rgba(255, 222, 200, 0.85));
+  color: var(--color-primary-strong);
+  box-shadow: 0 30px 60px -30px rgba(232, 93, 4, 0.4);
 }
 
 .recipe-card__favorite.is-favorite {
-  background: rgba(232, 93, 4, 0.2);
-  border-color: rgba(232, 93, 4, 0.4);
-  color: var(--color-primary-strong);
+  background: linear-gradient(145deg, rgba(232, 93, 4, 0.18), rgba(255, 183, 3, 0.28));
+  border-color: rgba(232, 93, 4, 0.55);
+  color: #fff;
+  box-shadow: 0 34px 70px -30px rgba(232, 93, 4, 0.58);
+}
+
+.recipe-card__favorite-icon {
+  display: grid;
+  place-items: center;
+}
+
+.recipe-card__favorite-icon svg {
+  width: 22px;
+  height: 22px;
 }
 
 .recipe-card__body {
@@ -86,12 +104,14 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  color: var(--color-heading);
+  text-shadow: 0 18px 36px rgba(232, 93, 4, 0.22);
 }
 
 .recipe-card__body p {
   margin: 0;
-  color: var(--color-muted);
-  font-size: 0.92rem;
+  color: var(--color-muted-strong);
+  font-size: 0.96rem;
   line-height: 1.6;
 }
 
@@ -148,9 +168,9 @@
   }
 
   .recipe-card__favorite {
-    width: 44px;
-    height: 44px;
-    top: 1rem;
-    right: 1rem;
+    width: 48px;
+    height: 48px;
+    top: 0.75rem;
+    right: 0.75rem;
   }
 }

--- a/frontend/src/pages/home.css
+++ b/frontend/src/pages/home.css
@@ -3,79 +3,176 @@
   gap: clamp(2rem, 4vw, 3rem);
 }
 
-.timeline__hero {
+.timeline__import {
   position: relative;
-  padding: var(--space-6);
+  display: grid;
+  gap: clamp(1.6rem, 3vw, 2.2rem);
+  padding: clamp(1.8rem, 3vw, 2.6rem);
   border-radius: var(--radius-lg);
   background:
-    radial-gradient(circle at 15% 20%, rgba(232, 93, 4, 0.35), transparent 55%),
-    radial-gradient(circle at 80% 10%, rgba(155, 89, 182, 0.4), transparent 60%),
-    linear-gradient(140deg, rgba(23, 28, 45, 0.96), rgba(18, 24, 42, 0.94));
-  color: #f7f8ff;
-  border: 1px solid rgba(255, 255, 255, 0.18);
+    radial-gradient(circle at 12% 20%, rgba(232, 93, 4, 0.24), transparent 58%),
+    radial-gradient(circle at 85% 12%, rgba(155, 89, 182, 0.2), transparent 65%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(255, 245, 236, 0.9));
+  border: 1px solid rgba(232, 93, 4, 0.18);
   box-shadow: var(--shadow-elevated);
   overflow: hidden;
 }
 
-:root[data-theme='dark'] .timeline__hero {
+:root[data-theme='dark'] .timeline__import {
   background:
-    radial-gradient(circle at 18% 18%, rgba(232, 93, 4, 0.38), transparent 60%),
-    radial-gradient(circle at 82% 12%, rgba(155, 89, 182, 0.45), transparent 65%),
-    linear-gradient(140deg, rgba(23, 20, 38, 0.92), rgba(16, 12, 28, 0.94));
-  border-color: rgba(236, 240, 247, 0.28);
+    radial-gradient(circle at 14% 18%, rgba(232, 93, 4, 0.32), transparent 60%),
+    radial-gradient(circle at 82% 12%, rgba(155, 89, 182, 0.34), transparent 62%),
+    linear-gradient(135deg, rgba(32, 24, 48, 0.94), rgba(26, 36, 54, 0.92));
+  border-color: rgba(236, 240, 247, 0.22);
 }
 
-.timeline__hero::after {
+.timeline__import::before {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 65% 70%, rgba(255, 255, 255, 0.18), transparent 68%);
-  mix-blend-mode: screen;
-  opacity: 0.6;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.4), transparent 55%);
   pointer-events: none;
 }
 
-.timeline__hero-inner {
+.timeline__import-header {
   position: relative;
   z-index: 1;
   display: grid;
   gap: var(--space-3);
-  max-width: 52ch;
+  max-width: 58ch;
+  color: var(--color-heading);
 }
 
-.timeline__hero-eyebrow {
+.timeline__import-eyebrow {
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-size: 0.72rem;
-  color: rgba(255, 255, 255, 0.65);
+  font-weight: 600;
+  color: rgba(215, 72, 15, 0.8);
 }
 
-.timeline__hero-title {
+.timeline__import-header h1 {
   margin: 0;
   font-family: 'Playfair Display', 'Times New Roman', serif;
-  font-size: clamp(1.75rem, 4vw, 2rem);
-  line-height: 1.32;
+  font-size: clamp(1.6rem, 4vw, 2rem);
+  line-height: 1.3;
 }
 
-.timeline__hero-subtitle {
+.timeline__import-header p {
   margin: 0;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--color-muted);
   font-size: 0.98rem;
   line-height: 1.65;
+}
+
+.timeline__import-form {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.timeline__import-field {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 0.5rem 0.6rem 0.5rem 0.5rem;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(232, 93, 4, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+:root[data-theme='dark'] .timeline__import-field {
+  background: rgba(24, 30, 46, 0.72);
+  border-color: rgba(255, 183, 3, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.timeline__import-field input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 0.98rem;
+  color: var(--color-heading);
+  padding: 0.4rem 0.75rem;
+}
+
+:root[data-theme='dark'] .timeline__import-field input {
+  color: var(--color-text);
+}
+
+.timeline__import-field input:focus {
+  outline: none;
+}
+
+.timeline__import-field button {
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 1.1rem;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: #fff;
+  background: linear-gradient(135deg, #e85d04 0%, #ff9f1c 100%);
+  box-shadow: 0 18px 40px -26px rgba(232, 93, 4, 0.5);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.timeline__import-field button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.timeline__import-field button:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 48px -26px rgba(232, 93, 4, 0.55);
+}
+
+.timeline__import-status {
+  margin: 0;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.timeline__import-status--idle {
+  color: rgba(31, 37, 40, 0.7);
+}
+
+.timeline__import-status--success {
+  color: var(--color-primary-strong);
+}
+
+.timeline__import-status--error {
+  color: #c1121f;
+}
+
+:root[data-theme='dark'] .timeline__import-status--idle {
+  color: rgba(236, 240, 247, 0.72);
+}
+
+:root[data-theme='dark'] .timeline__import-status--success {
+  color: #ffba08;
+}
+
+:root[data-theme='dark'] .timeline__import-status--error {
+  color: #ff6b6b;
 }
 
 .timeline__badge {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  padding: 0.4rem 0.85rem;
+  padding: 0.35rem 0.85rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.16);
-  border: 1px solid rgba(255, 255, 255, 0.24);
-  color: rgba(255, 255, 255, 0.92);
+  background: rgba(232, 93, 4, 0.12);
+  border: 1px solid rgba(232, 93, 4, 0.24);
+  color: var(--color-primary-strong);
   font-weight: 600;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   letter-spacing: 0.04em;
 }
 
@@ -182,30 +279,43 @@
 
 .timeline__carousel-favorite {
   position: absolute;
-  top: 1.1rem;
-  right: 1.1rem;
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.45);
-  background: rgba(17, 20, 28, 0.45);
-  color: rgba(255, 255, 255, 0.82);
+  top: 0.95rem;
+  right: 0.95rem;
+  width: 50px;
+  height: 50px;
+  border-radius: 18px;
+  border: 1px solid rgba(232, 93, 4, 0.28);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.82), rgba(255, 226, 200, 0.62));
+  color: var(--color-primary-strong);
   display: grid;
   place-items: center;
   cursor: pointer;
-  transition: transform 0.25s ease, background 0.25s ease, color 0.25s ease;
+  box-shadow: 0 24px 48px -30px rgba(18, 24, 42, 0.5);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  transition:
+    transform 0.25s ease,
+    background 0.25s ease,
+    color 0.25s ease,
+    box-shadow 0.25s ease;
 }
 
 .timeline__carousel-favorite:hover {
-  transform: translateY(-3px);
-  background: rgba(232, 93, 4, 0.4);
-  color: #fff;
+  transform: translateY(-3px) scale(1.02);
+  background: linear-gradient(145deg, rgba(255, 240, 228, 0.92), rgba(255, 220, 196, 0.78));
+  box-shadow: 0 30px 60px -30px rgba(232, 93, 4, 0.45);
 }
 
 .timeline__carousel-favorite.is-active {
-  background: rgba(232, 93, 4, 0.9);
-  border-color: rgba(255, 255, 255, 0.65);
+  background: linear-gradient(145deg, rgba(232, 93, 4, 0.22), rgba(255, 183, 3, 0.32));
+  border-color: rgba(232, 93, 4, 0.55);
   color: #fff;
+  box-shadow: 0 32px 64px -28px rgba(232, 93, 4, 0.55);
+}
+
+.timeline__carousel-favorite-icon svg {
+  width: 22px;
+  height: 22px;
 }
 
 .timeline__feed {
@@ -246,11 +356,11 @@
 }
 
 @media (max-width: 720px) {
-  .timeline__hero {
+  .timeline__import {
     border-radius: clamp(1.4rem, 6vw, 2.4rem);
   }
 
-  .timeline__hero-inner {
+  .timeline__import-header {
     gap: 0.75rem;
   }
 }
@@ -260,13 +370,24 @@
     gap: clamp(1.6rem, 6vw, 2.4rem);
   }
 
-  .timeline__hero {
+  .timeline__import {
     padding: clamp(1.5rem, 6vw, 2.2rem);
+  }
+
+  .timeline__import-field {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .timeline__import-field button {
+    width: 100%;
+    justify-content: center;
   }
 
   .timeline__carousel-track {
     grid-auto-columns: 75%;
   }
 }
+
 
 


### PR DESCRIPTION
## Summary
- replace the home hero with a quick import form, status messaging, and refreshed carousel titles
- refresh recipe favorite buttons with a chef hat icon, stronger blur, and brighter card typography
- align carousel favorite toggles with the new culinary styling and improve responsive behaviour

## Testing
- npm run lint *(fails: ESLint configuration is missing in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e34921bdf8832385dd748108e6e185