### PR TITLE
Update chat header and refresh brand gradient

### DIFF
--- a/frontend/src/components/chat/ChatDock.tsx
+++ b/frontend/src/components/chat/ChatDock.tsx
@@ -154,31 +154,6 @@ const ChatDock = ({ initialPrompt }: ChatDockProps) => {
         </button>
       </div>
 
-      {sessions.length > 1 ? (
-        <div className="chat-dock__tabs" role="tablist" aria-label="Conversas salvas">
-          {sessions.map((session) => {
-            const isActive = session.id === activeChatId;
-            return (
-              <button
-                key={session.id}
-                type="button"
-                role="tab"
-                aria-selected={isActive}
-                className={`chat-dock__tab${isActive ? ' is-active' : ''}`}
-                onClick={() => selectChat(session.id)}
-              >
-                <span className="chat-dock__tab-title" title={session.title}>
-                  {session.title}
-                </span>
-                <span className="chat-dock__tab-meta">
-                  {formatTabMeta(session.updatedAt, session.messageCount)}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
-
       <div className="chat-dock__history">
         {isLoading ? (
           <Loader />

--- a/frontend/src/components/layout/layout.css
+++ b/frontend/src/components/layout/layout.css
@@ -11,9 +11,9 @@
   --surface-elev: rgba(255, 255, 255, 0.9);
   --bottom-nav-bg: rgba(24, 28, 45, 0.85);
   --bottom-nav-border: rgba(255, 255, 255, 0.14);
-  --bottom-nav-active-color: #e85d04;
-  --bottom-nav-active-border: rgba(232, 93, 4, 0.35);
-  --brand: #e85d04;
+  --bottom-nav-active-color: #3d5af1;
+  --bottom-nav-active-border: rgba(61, 90, 241, 0.35);
+  --brand: #3d5af1;
   --accent: #9b59b6;
   --shadow-soft: 0 12px 32px -18px rgba(12, 18, 28, 0.4);
   --shadow-elevated: 0 24px 48px -26px rgba(12, 18, 28, 0.52);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,11 +17,11 @@
   --color-muted: rgba(31, 37, 40, 0.78);
   --color-muted-strong: rgba(31, 37, 40, 0.88);
   --color-heading: #13191b;
-  --color-primary: #e85d04;
-  --color-primary-strong: #d9480f;
-  --color-secondary: #9b59b6;
-  --color-secondary-soft: rgba(155, 89, 182, 0.2);
-  --gradient-brand: linear-gradient(135deg, #e85d04 0%, #ff9f1c 100%);
+  --color-primary: #3d5af1;
+  --color-primary-strong: #2737a6;
+  --color-secondary: #8c7ae6;
+  --color-secondary-soft: rgba(140, 122, 230, 0.2);
+  --gradient-brand: linear-gradient(135deg, #3d5af1 0%, #2737a6 100%);
   --color-chip-bg: rgba(45, 52, 54, 0.08);
   --color-search-bg: rgba(255, 255, 255, 0.92);
   --color-search-glow: rgba(255, 255, 255, 0.38);
@@ -38,8 +38,8 @@
   --topbar-search-focus-bg: rgba(255, 255, 255, 0.72);
   --topbar-search-border: rgba(255, 255, 255, 0.62);
   --topbar-search-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
-  --topbar-search-focus-border: rgba(232, 93, 4, 0.45);
-  --topbar-search-focus-shadow: rgba(232, 93, 4, 0.36);
+  --topbar-search-focus-border: rgba(61, 90, 241, 0.45);
+  --topbar-search-focus-shadow: rgba(61, 90, 241, 0.32);
   --topbar-search-card-bg: rgba(255, 255, 255, 0.58);
   --topbar-search-card-border: rgba(255, 255, 255, 0.7);
   --topbar-search-card-shadow: 0 30px 60px -36px rgba(15, 23, 42, 0.35);
@@ -49,15 +49,15 @@
   --topbar-toggle-shadow-hover: 0 26px 48px -28px rgba(15, 23, 42, 0.42);
   --topbar-chip-bg: rgba(255, 255, 255, 0.68);
   --topbar-chip-border: rgba(255, 255, 255, 0.78);
-  --topbar-chip-accent-bg: rgba(232, 93, 4, 0.18);
-  --topbar-chip-accent-border: rgba(232, 93, 4, 0.32);
+  --topbar-chip-accent-bg: rgba(61, 90, 241, 0.18);
+  --topbar-chip-accent-border: rgba(61, 90, 241, 0.32);
   --bottom-nav-bg: rgba(255, 255, 255, 0.78);
   --bottom-nav-border: rgba(255, 255, 255, 0.88);
   --bottom-nav-shadow: 0 34px 64px -38px rgba(15, 23, 42, 0.5);
-  --bottom-nav-active-bg: rgba(232, 93, 4, 0.18);
-  --bottom-nav-active-border: rgba(232, 93, 4, 0.3);
+  --bottom-nav-active-bg: rgba(61, 90, 241, 0.18);
+  --bottom-nav-active-border: rgba(61, 90, 241, 0.3);
   --bottom-nav-active-color: var(--color-heading);
-  --bottom-nav-icon-bg: rgba(232, 93, 4, 0.16);
+  --bottom-nav-icon-bg: rgba(61, 90, 241, 0.16);
   --chat-history-bg: rgba(247, 248, 255, 0.66);
   --chat-input-bg: rgba(255, 255, 255, 0.92);
   --chat-input-border: rgba(16, 22, 41, 0.08);
@@ -67,8 +67,8 @@
   --chat-textarea-border: rgba(16, 22, 41, 0.12);
   --chat-textarea-text: var(--color-text);
   --chat-textarea-placeholder: rgba(31, 37, 40, 0.5);
-  --chat-send-button-bg: linear-gradient(135deg, #e85d04 0%, #ff9f1c 100%);
-  --chat-send-button-shadow: 0 24px 44px -30px rgba(232, 93, 4, 0.55);
+  --chat-send-button-bg: linear-gradient(135deg, #3d5af1 0%, #2737a6 100%);
+  --chat-send-button-shadow: 0 24px 44px -30px rgba(61, 90, 241, 0.55);
   --chat-send-button-disabled-opacity: 0.6;
   --radius-xl: 32px;
   --radius-lg: 24px;
@@ -84,15 +84,15 @@
   --cooking-border: rgba(34, 25, 29, 0.1);
   --cooking-text: #1f1a1b;
   --cooking-muted: rgba(34, 25, 29, 0.68);
-  --cooking-progress-track: rgba(232, 93, 4, 0.18);
-  --cooking-progress-fill: linear-gradient(135deg, #e85d04 0%, #ffba08 100%);
+  --cooking-progress-track: rgba(61, 90, 241, 0.18);
+  --cooking-progress-fill: linear-gradient(135deg, #3d5af1 0%, #2737a6 100%);
   --cooking-control-bg: rgba(34, 25, 29, 0.08);
   --cooking-control-border: rgba(34, 25, 29, 0.14);
-  --cooking-control-hover: rgba(232, 93, 4, 0.16);
+  --cooking-control-hover: rgba(61, 90, 241, 0.16);
   --cooking-control-text: #1f1a1b;
-  --cooking-voice-bg: rgba(232, 93, 4, 0.12);
-  --cooking-voice-border: rgba(232, 93, 4, 0.32);
-  --cooking-voice-active-glow: rgba(232, 93, 4, 0.28);
+  --cooking-voice-bg: rgba(61, 90, 241, 0.12);
+  --cooking-voice-border: rgba(61, 90, 241, 0.32);
+  --cooking-voice-active-glow: rgba(61, 90, 241, 0.28);
   --cooking-tip-text: rgba(34, 25, 29, 0.72);
   --cooking-ingredients-bg: rgba(255, 255, 255, 0.94);
   --cooking-ingredients-border: rgba(232, 93, 4, 0.2);
@@ -133,8 +133,8 @@
   --topbar-search-focus-bg: rgba(24, 34, 52, 0.82);
   --topbar-search-border: rgba(236, 240, 247, 0.24);
   --topbar-search-shadow: inset 0 1px 0 rgba(236, 240, 247, 0.12);
-  --topbar-search-focus-border: rgba(255, 183, 3, 0.5);
-  --topbar-search-focus-shadow: rgba(255, 183, 3, 0.38);
+  --topbar-search-focus-border: rgba(124, 144, 255, 0.55);
+  --topbar-search-focus-shadow: rgba(124, 144, 255, 0.4);
   --topbar-search-card-bg: rgba(26, 34, 52, 0.82);
   --topbar-search-card-border: rgba(236, 240, 247, 0.22);
   --topbar-search-card-shadow: 0 34px 64px -32px rgba(2, 8, 20, 0.75);
@@ -144,16 +144,16 @@
   --topbar-toggle-shadow-hover: 0 30px 54px -32px rgba(0, 0, 0, 0.7);
   --topbar-chip-bg: rgba(236, 240, 247, 0.14);
   --topbar-chip-border: rgba(236, 240, 247, 0.24);
-  --topbar-chip-accent-bg: rgba(255, 183, 3, 0.22);
-  --topbar-chip-accent-border: rgba(255, 183, 3, 0.32);
+  --topbar-chip-accent-bg: rgba(124, 144, 255, 0.28);
+  --topbar-chip-accent-border: rgba(124, 144, 255, 0.38);
   --bottom-nav-bg: rgba(24, 32, 52, 0.82);
   --bottom-nav-border: rgba(236, 240, 247, 0.22);
   --bottom-nav-shadow: 0 34px 66px -34px rgba(0, 0, 0, 0.72);
-  --bottom-nav-active-bg: rgba(255, 183, 3, 0.26);
-  --bottom-nav-active-border: rgba(255, 183, 3, 0.38);
+  --bottom-nav-active-bg: rgba(124, 144, 255, 0.28);
+  --bottom-nav-active-border: rgba(124, 144, 255, 0.4);
   --bottom-nav-active-color: #ffffff;
-  --bottom-nav-icon-bg: rgba(255, 183, 3, 0.14);
-  --gradient-brand: linear-gradient(135deg, #ff9f1c 0%, #f48c06 45%, #e85d04 100%);
+  --bottom-nav-icon-bg: rgba(124, 144, 255, 0.18);
+  --gradient-brand: linear-gradient(135deg, #4c6ef5 0%, #364fc7 100%);
   --chat-history-bg: linear-gradient(145deg, rgba(32, 42, 60, 0.82), rgba(26, 34, 52, 0.88));
   --chat-input-bg: linear-gradient(145deg, rgba(28, 36, 54, 0.92), rgba(24, 30, 46, 0.9));
   --chat-input-border: rgba(236, 240, 247, 0.16);
@@ -163,8 +163,8 @@
   --chat-textarea-border: rgba(236, 240, 247, 0.18);
   --chat-textarea-text: #f0f4f8;
   --chat-textarea-placeholder: rgba(236, 240, 247, 0.6);
-  --chat-send-button-bg: linear-gradient(135deg, #ffb703 0%, #f48c06 50%, #e85d04 100%);
-  --chat-send-button-shadow: 0 28px 48px -26px rgba(232, 93, 4, 0.65);
+  --chat-send-button-bg: linear-gradient(135deg, #748ffc 0%, #5c7cfa 50%, #364fc7 100%);
+  --chat-send-button-shadow: 0 28px 48px -26px rgba(76, 110, 245, 0.6);
   --chat-send-button-disabled-opacity: 0.5;
   --cooking-body-bg: radial-gradient(circle at 18% 14%, rgba(232, 93, 4, 0.22), transparent 60%),
     radial-gradient(circle at 78% 18%, rgba(155, 89, 182, 0.26), transparent 58%),
@@ -179,11 +179,11 @@
   --cooking-progress-fill: linear-gradient(135deg, #f48c06 0%, #ffba08 100%);
   --cooking-control-bg: rgba(236, 240, 247, 0.14);
   --cooking-control-border: rgba(236, 240, 247, 0.26);
-  --cooking-control-hover: rgba(232, 93, 4, 0.3);
+  --cooking-control-hover: rgba(76, 110, 245, 0.32);
   --cooking-control-text: #f5f7fb;
   --cooking-voice-bg: rgba(236, 240, 247, 0.18);
   --cooking-voice-border: rgba(236, 240, 247, 0.32);
-  --cooking-voice-active-glow: rgba(232, 93, 4, 0.36);
+  --cooking-voice-active-glow: rgba(76, 110, 245, 0.36);
   --cooking-tip-text: rgba(236, 240, 247, 0.85);
   --cooking-ingredients-bg: linear-gradient(145deg, rgba(42, 32, 68, 0.94), rgba(26, 34, 52, 0.92));
   --cooking-ingredients-border: rgba(236, 240, 247, 0.26);
@@ -225,8 +225,8 @@
     --topbar-search-focus-bg: rgba(24, 34, 52, 0.82);
     --topbar-search-border: rgba(236, 240, 247, 0.24);
     --topbar-search-shadow: inset 0 1px 0 rgba(236, 240, 247, 0.12);
-    --topbar-search-focus-border: rgba(255, 183, 3, 0.5);
-    --topbar-search-focus-shadow: rgba(255, 183, 3, 0.38);
+    --topbar-search-focus-border: rgba(124, 144, 255, 0.55);
+    --topbar-search-focus-shadow: rgba(124, 144, 255, 0.4);
     --topbar-search-card-bg: rgba(26, 34, 52, 0.82);
     --topbar-search-card-border: rgba(236, 240, 247, 0.22);
     --topbar-search-card-shadow: 0 34px 64px -32px rgba(2, 8, 20, 0.75);
@@ -236,16 +236,16 @@
     --topbar-toggle-shadow-hover: 0 30px 54px -32px rgba(0, 0, 0, 0.7);
     --topbar-chip-bg: rgba(236, 240, 247, 0.14);
     --topbar-chip-border: rgba(236, 240, 247, 0.24);
-    --topbar-chip-accent-bg: rgba(255, 183, 3, 0.22);
-    --topbar-chip-accent-border: rgba(255, 183, 3, 0.32);
+    --topbar-chip-accent-bg: rgba(124, 144, 255, 0.28);
+    --topbar-chip-accent-border: rgba(124, 144, 255, 0.38);
     --bottom-nav-bg: rgba(24, 32, 52, 0.82);
     --bottom-nav-border: rgba(236, 240, 247, 0.22);
     --bottom-nav-shadow: 0 34px 66px -34px rgba(0, 0, 0, 0.72);
-    --bottom-nav-active-bg: rgba(255, 183, 3, 0.26);
-    --bottom-nav-active-border: rgba(255, 183, 3, 0.38);
+    --bottom-nav-active-bg: rgba(124, 144, 255, 0.28);
+    --bottom-nav-active-border: rgba(124, 144, 255, 0.4);
     --bottom-nav-active-color: #ffffff;
-    --bottom-nav-icon-bg: rgba(255, 183, 3, 0.14);
-    --gradient-brand: linear-gradient(135deg, #ff9f1c 0%, #f48c06 45%, #e85d04 100%);
+    --bottom-nav-icon-bg: rgba(124, 144, 255, 0.18);
+    --gradient-brand: linear-gradient(135deg, #4c6ef5 0%, #364fc7 100%);
     --chat-history-bg: linear-gradient(145deg, rgba(32, 42, 60, 0.82), rgba(26, 34, 52, 0.88));
     --chat-input-bg: linear-gradient(145deg, rgba(28, 36, 54, 0.92), rgba(24, 30, 46, 0.9));
     --chat-input-border: rgba(236, 240, 247, 0.16);
@@ -255,8 +255,8 @@
     --chat-textarea-border: rgba(236, 240, 247, 0.18);
     --chat-textarea-text: #f0f4f8;
     --chat-textarea-placeholder: rgba(236, 240, 247, 0.6);
-    --chat-send-button-bg: linear-gradient(135deg, #ffb703 0%, #f48c06 50%, #e85d04 100%);
-    --chat-send-button-shadow: 0 28px 48px -26px rgba(232, 93, 4, 0.65);
+    --chat-send-button-bg: linear-gradient(135deg, #748ffc 0%, #5c7cfa 50%, #364fc7 100%);
+    --chat-send-button-shadow: 0 28px 48px -26px rgba(76, 110, 245, 0.6);
     --chat-send-button-disabled-opacity: 0.5;
     --cooking-body-bg: radial-gradient(circle at 18% 14%, rgba(232, 93, 4, 0.22), transparent 60%),
       radial-gradient(circle at 78% 18%, rgba(155, 89, 182, 0.26), transparent 58%),
@@ -268,14 +268,14 @@
     --cooking-text: #f5f7fb;
     --cooking-muted: rgba(236, 240, 247, 0.82);
     --cooking-progress-track: rgba(236, 240, 247, 0.24);
-    --cooking-progress-fill: linear-gradient(135deg, #f48c06 0%, #ffba08 100%);
+    --cooking-progress-fill: linear-gradient(135deg, #748ffc 0%, #4c6ef5 100%);
     --cooking-control-bg: rgba(236, 240, 247, 0.14);
     --cooking-control-border: rgba(236, 240, 247, 0.26);
-    --cooking-control-hover: rgba(232, 93, 4, 0.3);
+    --cooking-control-hover: rgba(76, 110, 245, 0.32);
     --cooking-control-text: #f5f7fb;
     --cooking-voice-bg: rgba(236, 240, 247, 0.18);
     --cooking-voice-border: rgba(236, 240, 247, 0.32);
-    --cooking-voice-active-glow: rgba(232, 93, 4, 0.36);
+    --cooking-voice-active-glow: rgba(76, 110, 245, 0.36);
     --cooking-tip-text: rgba(236, 240, 247, 0.85);
     --cooking-ingredients-bg: linear-gradient(145deg, rgba(42, 32, 68, 0.94), rgba(26, 34, 52, 0.92));
     --cooking-ingredients-border: rgba(236, 240, 247, 0.26);
@@ -291,9 +291,9 @@ body {
   margin: 0;
   min-height: 100vh;
   background:
-    radial-gradient(circle at 12% 20%, rgba(232, 93, 4, 0.12), transparent 55%),
-    radial-gradient(circle at 88% 12%, rgba(155, 89, 182, 0.16), transparent 45%),
-    radial-gradient(circle at 24% 78%, rgba(232, 93, 4, 0.12), transparent 50%),
+    radial-gradient(circle at 12% 20%, rgba(76, 110, 245, 0.14), transparent 55%),
+    radial-gradient(circle at 88% 12%, rgba(140, 122, 230, 0.16), transparent 45%),
+    radial-gradient(circle at 24% 78%, rgba(58, 92, 210, 0.12), transparent 50%),
     var(--color-canvas);
   color: var(--color-text);
   transition: background 0.3s ease, color 0.3s ease;
@@ -305,7 +305,7 @@ body::before {
   inset: 0;
   pointer-events: none;
   background:
-    linear-gradient(135deg, rgba(232, 93, 4, 0.05), rgba(155, 89, 182, 0.09)),
+    linear-gradient(135deg, rgba(76, 110, 245, 0.08), rgba(140, 122, 230, 0.12)),
     radial-gradient(circle at 20% 50%, rgba(255, 255, 255, 0.4), transparent 55%);
   mix-blend-mode: screen;
   opacity: 0.7;
@@ -314,15 +314,15 @@ body::before {
 
 :root[data-theme='dark'] body {
   background:
-    radial-gradient(circle at 12% 18%, rgba(232, 93, 4, 0.14), transparent 55%),
-    radial-gradient(circle at 82% 18%, rgba(155, 89, 182, 0.2), transparent 44%),
-    linear-gradient(135deg, rgba(232, 93, 4, 0.08), rgba(155, 89, 182, 0.16)),
+    radial-gradient(circle at 12% 18%, rgba(76, 110, 245, 0.2), transparent 55%),
+    radial-gradient(circle at 82% 18%, rgba(140, 122, 230, 0.26), transparent 44%),
+    linear-gradient(135deg, rgba(76, 110, 245, 0.12), rgba(140, 122, 230, 0.2)),
     var(--color-canvas);
 }
 
 :root[data-theme='dark'] body::before {
   background:
-    linear-gradient(135deg, rgba(232, 93, 4, 0.12), rgba(155, 89, 182, 0.18)),
+    linear-gradient(135deg, rgba(76, 110, 245, 0.18), rgba(140, 122, 230, 0.24)),
     radial-gradient(circle at 18% 52%, rgba(255, 255, 255, 0.22), transparent 55%);
   mix-blend-mode: screen;
   opacity: 0.6;
@@ -493,9 +493,9 @@ select:focus {
 }
 
 .button--primary {
-  background: linear-gradient(135deg, #e85d04 0%, #f48c06 100%);
+  background: linear-gradient(135deg, #3d5af1 0%, #2737a6 100%);
   color: #fff;
-  box-shadow: 0 32px 52px -32px rgba(232, 93, 4, 0.65);
+  box-shadow: 0 32px 52px -32px rgba(61, 90, 241, 0.65);
   border: none;
 }
 
@@ -538,7 +538,7 @@ select:focus {
   width: 64px;
   height: 64px;
   border-radius: 24px;
-  background: linear-gradient(135deg, #e85d04, #ff9f1c);
+  background: linear-gradient(135deg, #4c6ef5, #364fc7);
   color: #fff;
   display: grid;
   place-items: center;
@@ -546,14 +546,14 @@ select:focus {
   font-weight: 600;
   border: none;
   cursor: pointer;
-  box-shadow: 0 32px 60px -30px rgba(232, 93, 4, 0.65);
+  box-shadow: 0 32px 60px -30px rgba(76, 110, 245, 0.65);
   transition: transform 0.25s ease, box-shadow 0.25s ease;
   z-index: 20;
 }
 
 .fab:hover {
   transform: translateY(-4px) scale(1.03);
-  box-shadow: 0 42px 70px -32px rgba(232, 93, 4, 0.75);
+  box-shadow: 0 42px 70px -32px rgba(76, 110, 245, 0.75);
 }
 
 .fab:active {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -35,9 +35,9 @@ const ChatPage = () => {
     <div className="chat-page">
       <header className="chat-page__header">
         <span className="chat-page__eyebrow">Chef IA</span>
-        <h1 className="chat-page__title">Planeje, ajuste e aprenda em tempo real</h1>
+        <h1 className="chat-page__title">Converse com a Chef IA sempre que precisar</h1>
         <p className="chat-page__subtitle">
-          O chat acompanha cada receita e traz técnicas, substituições e ideias comerciais para o seu livro digital.
+          Tire dúvidas rápidas, ajuste receitas em segundos e mantenha o fluxo da cozinha em um só lugar.
         </p>
       </header>
       <div className="chat-page__body">

--- a/frontend/src/pages/home.css
+++ b/frontend/src/pages/home.css
@@ -115,8 +115,8 @@
   font-weight: 700;
   font-size: 0.95rem;
   color: #fff;
-  background: linear-gradient(135deg, #e85d04 0%, #ff9f1c 100%);
-  box-shadow: 0 18px 40px -26px rgba(232, 93, 4, 0.5);
+  background: linear-gradient(135deg, #3d5af1 0%, #2737a6 100%);
+  box-shadow: 0 18px 40px -26px rgba(61, 90, 241, 0.5);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
@@ -129,7 +129,7 @@
 
 .timeline__import-field button:not(:disabled):hover {
   transform: translateY(-2px);
-  box-shadow: 0 24px 48px -26px rgba(232, 93, 4, 0.55);
+  box-shadow: 0 24px 48px -26px rgba(61, 90, 241, 0.55);
 }
 
 .timeline__import-status {


### PR DESCRIPTION
## Summary
- simplify the chat dock by relying on a single tab strip and tightening the intro copy on the chat page
- retune global color variables and gradients toward the darker blue palette used elsewhere in the app
- update shared button styles and home import CTA to reflect the new brand gradient

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e406a87dcc83239b52db1452bf7111