### PR TITLE
feat: redesign saved recipes view with playlist collections

### DIFF
--- a/frontend/src/components/saved/SavedCollectionsView.tsx
+++ b/frontend/src/components/saved/SavedCollectionsView.tsx
@@ -1,0 +1,384 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+
+import RecipeGrid from '../../components/recipes/RecipeGrid';
+import type { Recipe } from '../../types';
+
+import './saved-collections.css';
+
+type SavedCollectionType = 'all' | 'custom' | 'tag';
+
+type SavedCollection = {
+  id: string;
+  name: string;
+  recipeIds: string[];
+  createdAt: string;
+  type: SavedCollectionType;
+};
+
+const STORAGE_KEY = 'recipe-ai:saved-collections';
+const FALLBACK_COVER =
+  'linear-gradient(135deg, rgba(155, 89, 182, 0.32), rgba(232, 93, 4, 0.32)), url(https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=1200&q=60)';
+
+type SavedCollectionsViewProps = {
+  favorites: Recipe[];
+  onOpenRecipe: (id: string) => void;
+  onToggleFavorite: (id: string) => Promise<void>;
+};
+
+type CreateCollectionState = {
+  isOpen: boolean;
+  name: string;
+  selectedRecipes: Record<string, boolean>;
+  error?: string;
+};
+
+const buildDefaultCollection = (recipes: Recipe[]): SavedCollection => ({
+  id: 'all-favorites',
+  name: 'Todos os favoritos',
+  recipeIds: recipes.map((recipe) => recipe.id),
+  createdAt: '1970-01-01T00:00:00.000Z',
+  type: 'all'
+});
+
+const SavedCollectionsView = ({ favorites, onOpenRecipe, onToggleFavorite }: SavedCollectionsViewProps) => {
+  const [customCollections, setCustomCollections] = useState<SavedCollection[]>(() => {
+    if (typeof window === 'undefined') {
+      return [];
+    }
+
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        return [];
+      }
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed.filter((collection): collection is SavedCollection => {
+        return (
+          typeof collection?.id === 'string' &&
+          typeof collection?.name === 'string' &&
+          Array.isArray(collection?.recipeIds) &&
+          typeof collection?.createdAt === 'string'
+        );
+      });
+    } catch (error) {
+      console.warn('Unable to parse saved collections', error);
+      return [];
+    }
+  });
+
+  const [creationState, setCreationState] = useState<CreateCollectionState>({
+    isOpen: false,
+    name: '',
+    selectedRecipes: {}
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(customCollections));
+  }, [customCollections]);
+
+  useEffect(() => {
+    setCreationState((prev) => ({
+      ...prev,
+      selectedRecipes: favorites.reduce<Record<string, boolean>>((acc, recipe) => {
+        if (prev.selectedRecipes[recipe.id]) {
+          acc[recipe.id] = true;
+        }
+        return acc;
+      }, {})
+    }));
+  }, [favorites]);
+
+  const tagCollections = useMemo(() => {
+    const tagMap = new Map<string, Set<string>>();
+
+    favorites.forEach((recipe) => {
+      recipe.tags?.forEach((tag) => {
+        const normalizedTag = tag.trim();
+        if (!normalizedTag) {
+          return;
+        }
+        if (!tagMap.has(normalizedTag)) {
+          tagMap.set(normalizedTag, new Set());
+        }
+        tagMap.get(normalizedTag)?.add(recipe.id);
+      });
+    });
+
+    const collectionEntries = Array.from(tagMap.entries()).map<SavedCollection>(([tag, recipeSet]) => ({
+      id: `tag-${tag.toLowerCase().replace(/[^a-z0-9]+/gi, '-')}`,
+      name: tag,
+      recipeIds: Array.from(recipeSet),
+      createdAt: '1970-01-02T00:00:00.000Z',
+      type: 'tag'
+    }));
+
+    return collectionEntries.sort((a, b) => b.recipeIds.length - a.recipeIds.length).slice(0, 12);
+  }, [favorites]);
+
+  const collections = useMemo(() => {
+    const defaultCollection = buildDefaultCollection(favorites);
+    const filteredCustomCollections = customCollections.map((collection) => ({
+      ...collection,
+      recipeIds: collection.recipeIds.filter((recipeId) => favorites.some((recipe) => recipe.id === recipeId))
+    }));
+
+    return [
+      defaultCollection,
+      ...filteredCustomCollections.sort((a, b) => b.createdAt.localeCompare(a.createdAt)),
+      ...tagCollections
+    ];
+  }, [customCollections, favorites, tagCollections]);
+
+  const [selectedCollectionId, setSelectedCollectionId] = useState<string>(() =>
+    collections.length ? collections[0].id : ''
+  );
+
+  useEffect(() => {
+    if (!collections.length) {
+      setSelectedCollectionId('');
+      return;
+    }
+
+    const current = collections.find((collection) => collection.id === selectedCollectionId);
+    if (!current) {
+      setSelectedCollectionId(collections[0].id);
+    }
+  }, [collections, selectedCollectionId]);
+
+  const selectedCollection = collections.find((collection) => collection.id === selectedCollectionId);
+
+  const selectedRecipes = useMemo(() => {
+    if (!selectedCollection) {
+      return [];
+    }
+    return selectedCollection.recipeIds
+      .map((id) => favorites.find((recipe) => recipe.id === id))
+      .filter((recipe): recipe is Recipe => Boolean(recipe));
+  }, [favorites, selectedCollection]);
+
+  const handleOpenCreation = () => {
+    setCreationState({
+      isOpen: true,
+      name: '',
+      selectedRecipes: favorites.reduce<Record<string, boolean>>((acc, recipe) => {
+        acc[recipe.id] = true;
+        return acc;
+      }, {})
+    });
+  };
+
+  const handleToggleSelection = (recipeId: string) => {
+    setCreationState((prev) => ({
+      ...prev,
+      selectedRecipes: {
+        ...prev.selectedRecipes,
+        [recipeId]: !prev.selectedRecipes[recipeId]
+      }
+    }));
+  };
+
+  const handleCreateCollection = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedName = creationState.name.trim();
+    if (!trimmedName) {
+      setCreationState((prev) => ({ ...prev, error: 'Informe um nome para a playlist.' }));
+      return;
+    }
+
+    if (collections.some((collection) => collection.name.toLowerCase() === trimmedName.toLowerCase())) {
+      setCreationState((prev) => ({ ...prev, error: 'Ja existe uma playlist com esse nome.' }));
+      return;
+    }
+
+    const recipeIds = Object.entries(creationState.selectedRecipes)
+      .filter(([, isSelected]) => isSelected)
+      .map(([recipeId]) => recipeId);
+
+    if (!recipeIds.length) {
+      setCreationState((prev) => ({ ...prev, error: 'Selecione ao menos uma receita para a playlist.' }));
+      return;
+    }
+
+    const newCollection: SavedCollection = {
+      id: `custom-${Date.now()}`,
+      name: trimmedName,
+      recipeIds,
+      createdAt: new Date().toISOString(),
+      type: 'custom'
+    };
+
+    setCustomCollections((prev) => [newCollection, ...prev]);
+    setCreationState({ isOpen: false, name: '', selectedRecipes: {} });
+    setSelectedCollectionId(newCollection.id);
+  };
+
+  const handleCloseCreation = () => {
+    setCreationState({ isOpen: false, name: '', selectedRecipes: {} });
+  };
+
+  const handleRemoveCustomCollection = (collectionId: string) => {
+    setCustomCollections((prev) => prev.filter((collection) => collection.id !== collectionId));
+
+    if (selectedCollectionId === collectionId) {
+      const nextCollection = collections.find((collection) => collection.id !== collectionId);
+      setSelectedCollectionId(nextCollection ? nextCollection.id : '');
+    }
+  };
+
+  const renderCover = (collection: SavedCollection) => {
+    const firstRecipe = collection.recipeIds
+      .map((id) => favorites.find((recipe) => recipe.id === id))
+      .find((recipe) => Boolean(recipe));
+
+    const coverStyle = firstRecipe?.coverImage
+      ? { backgroundImage: `url(${firstRecipe.coverImage})` }
+      : { backgroundImage: FALLBACK_COVER };
+
+    return <div className="saved-collections__card-cover" style={coverStyle} aria-hidden="true" />;
+  };
+
+  if (!favorites.length) {
+    return (
+      <div className="saved-collections saved-collections--empty">
+        <div className="saved-collections__empty-card">
+          <h2>Sem favoritos ainda</h2>
+          <p>Adicione receitas aos favoritos para organizar suas playlists aqui.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="saved-collections">
+      <header className="saved-collections__header">
+        <div>
+          <p className="saved-collections__eyebrow">Suas playlists</p>
+          <h1>Salvos</h1>
+        </div>
+        <button type="button" className="saved-collections__create" onClick={handleOpenCreation}>
+          <span aria-hidden="true">＋</span>
+          Nova playlist
+        </button>
+      </header>
+
+      <div className="saved-collections__grid" role="list">
+        {collections.map((collection) => {
+          const isActive = collection.id === selectedCollectionId;
+          return (
+            <button
+              key={collection.id}
+              type="button"
+              role="listitem"
+              className={`saved-collections__card${isActive ? ' is-active' : ''}`}
+              onClick={() => setSelectedCollectionId(collection.id)}
+            >
+              <div className="saved-collections__card-media">
+                {renderCover(collection)}
+                <div className="saved-collections__card-overlay" aria-hidden="true" />
+                <span className="saved-collections__card-count">{collection.recipeIds.length} receitas</span>
+              </div>
+              <span className="saved-collections__card-name">{collection.name}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {selectedCollection ? (
+        <section className="saved-collections__detail">
+          <header className="saved-collections__detail-header">
+            <div>
+              <h2>{selectedCollection.name}</h2>
+              <p className="text-muted">
+                {selectedCollection.recipeIds.length}{' '}
+                {selectedCollection.recipeIds.length === 1 ? 'receita' : 'receitas'} nesta playlist
+              </p>
+            </div>
+            {selectedCollection.type === 'custom' ? (
+              <button
+                type="button"
+                className="saved-collections__delete"
+                onClick={() => handleRemoveCustomCollection(selectedCollection.id)}
+              >
+                Remover playlist
+              </button>
+            ) : null}
+          </header>
+
+          <RecipeGrid
+            recipes={selectedRecipes}
+            onOpenRecipe={onOpenRecipe}
+            onToggleFavorite={onToggleFavorite}
+            emptyMessage="Esta playlist ainda nao possui receitas."
+          />
+        </section>
+      ) : null}
+
+      {creationState.isOpen ? (
+        <div className="saved-collections__modal" role="dialog" aria-modal="true" aria-labelledby="saved-collections-create-title">
+          <div className="saved-collections__modal-content">
+            <header className="saved-collections__modal-header">
+              <h2 id="saved-collections-create-title">Nova playlist</h2>
+              <button type="button" onClick={handleCloseCreation} aria-label="Fechar">
+                ×
+              </button>
+            </header>
+            <form className="saved-collections__modal-form" onSubmit={handleCreateCollection}>
+              <label className="saved-collections__modal-field">
+                <span>Nome da playlist</span>
+                <input
+                  type="text"
+                  value={creationState.name}
+                  onChange={(event) =>
+                    setCreationState((prev) => ({ ...prev, name: event.target.value, error: undefined }))
+                  }
+                  placeholder="Ex: Receitas rápidas"
+                  autoFocus
+                  required
+                />
+              </label>
+
+              <fieldset className="saved-collections__modal-field">
+                <legend>Escolha as receitas favoritas</legend>
+                <div className="saved-collections__modal-recipes">
+                  {favorites.map((recipe) => (
+                    <label key={recipe.id} className="saved-collections__modal-recipe">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(creationState.selectedRecipes[recipe.id])}
+                        onChange={() => handleToggleSelection(recipe.id)}
+                      />
+                      <span>{recipe.title}</span>
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+
+              {creationState.error ? (
+                <p className="saved-collections__modal-error">{creationState.error}</p>
+              ) : null}
+
+              <footer className="saved-collections__modal-actions">
+                <button type="button" onClick={handleCloseCreation} className="saved-collections__cancel">
+                  Cancelar
+                </button>
+                <button type="submit" className="saved-collections__confirm">
+                  Criar playlist
+                </button>
+              </footer>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default SavedCollectionsView;

--- a/frontend/src/components/saved/saved-collections.css
+++ b/frontend/src/components/saved/saved-collections.css
@@ -1,0 +1,301 @@
+.saved-collections {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 1.5rem 1.25rem 5rem;
+}
+
+.saved-collections--empty {
+  align-items: center;
+  justify-content: center;
+}
+
+.saved-collections__empty-card {
+  max-width: 22rem;
+  text-align: center;
+  background: var(--surface-card, #151515);
+  border-radius: 1.25rem;
+  padding: 3rem 2rem;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.2);
+}
+
+.saved-collections__empty-card h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.saved-collections__empty-card p {
+  color: var(--text-muted, rgba(255, 255, 255, 0.64));
+}
+
+.saved-collections__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.saved-collections__eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: var(--text-muted, rgba(255, 255, 255, 0.64));
+  margin-bottom: 0.35rem;
+}
+
+.saved-collections__header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.saved-collections__create {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 0.65rem 1.1rem;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.saved-collections__create:hover,
+.saved-collections__create:focus {
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateY(-1px);
+}
+
+.saved-collections__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(9.5rem, 1fr));
+  gap: 1.25rem;
+}
+
+.saved-collections__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  text-align: left;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.saved-collections__card-media {
+  position: relative;
+  border-radius: 1rem;
+  overflow: hidden;
+  aspect-ratio: 1 / 1;
+  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.35);
+}
+
+.saved-collections__card-cover {
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+  filter: saturate(1.1);
+  transform: scale(1.02);
+  transition: transform 0.3s ease;
+}
+
+.saved-collections__card-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 100%);
+  opacity: 0.75;
+  transition: opacity 0.3s ease;
+}
+
+.saved-collections__card-count {
+  position: absolute;
+  left: 0.75rem;
+  bottom: 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.saved-collections__card-name {
+  font-weight: 600;
+  font-size: 1rem;
+  text-transform: capitalize;
+}
+
+.saved-collections__card.is-active .saved-collections__card-cover,
+.saved-collections__card:hover .saved-collections__card-cover {
+  transform: scale(1.05);
+}
+
+.saved-collections__card.is-active .saved-collections__card-overlay,
+.saved-collections__card:hover .saved-collections__card-overlay {
+  opacity: 0.55;
+}
+
+.saved-collections__detail {
+  background: var(--surface-card, #151515);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.25);
+}
+
+.saved-collections__detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+  gap: 1rem;
+}
+
+.saved-collections__delete {
+  background: rgba(255, 59, 59, 0.15);
+  color: #ff7b7b;
+  border: 1px solid rgba(255, 59, 59, 0.25);
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  transition: background 0.2s ease;
+}
+
+.saved-collections__delete:hover,
+.saved-collections__delete:focus {
+  background: rgba(255, 59, 59, 0.25);
+}
+
+.saved-collections__modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.saved-collections__modal-content {
+  width: min(32rem, 100%);
+  background: var(--surface-card, #1c1c1c);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+}
+
+.saved-collections__modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.saved-collections__modal-header button {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.saved-collections__modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.saved-collections__modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.saved-collections__modal-field input[type='text'] {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.75rem 1rem;
+  color: inherit;
+}
+
+.saved-collections__modal-recipes {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+  gap: 0.75rem;
+  max-height: 14rem;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.saved-collections__modal-recipe {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.saved-collections__modal-recipe input {
+  accent-color: var(--accent-color, #ff9654);
+}
+
+.saved-collections__modal-error {
+  color: #ff7b7b;
+  font-weight: 600;
+}
+
+.saved-collections__modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.saved-collections__cancel,
+.saved-collections__confirm {
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
+}
+
+.saved-collections__cancel {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.saved-collections__confirm {
+  background: linear-gradient(135deg, #ff9654, #ff5c7a);
+  color: #120c07;
+  border: none;
+}
+
+@media (min-width: 768px) {
+  .saved-collections {
+    padding: 2rem 2.5rem 6rem;
+  }
+
+  .saved-collections__grid {
+    gap: 1.5rem;
+  }
+
+  .saved-collections__card-name {
+    font-size: 1.1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .saved-collections {
+    padding-bottom: 7rem;
+  }
+
+  .saved-collections__grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import Loader from '../components/shared/Loader';
 import RecipeGrid from '../components/recipes/RecipeGrid';
+import SavedCollectionsView from '../components/saved/SavedCollectionsView';
 import { useAuth } from '../context/AuthContext';
 import { useRecipes } from '../context/RecipeContext';
 import type { Recipe } from '../types';
@@ -233,6 +234,18 @@ const HomePage = () => {
           <Loader />
           <p>Organizando seu atelier...</p>
         </section>
+      </div>
+    );
+  }
+
+  if (view === 'favorites') {
+    return (
+      <div className="timeline timeline--favorites">
+        <SavedCollectionsView
+          favorites={favoritesCarousel}
+          onOpenRecipe={(id) => navigate(`/app/recipes/${id}`)}
+          onToggleFavorite={toggleFavorite}
+        />
       </div>
     );
   }

--- a/frontend/src/pages/home.css
+++ b/frontend/src/pages/home.css
@@ -3,6 +3,10 @@
   gap: clamp(2rem, 4vw, 3rem);
 }
 
+.timeline--favorites {
+  display: block;
+}
+
 .timeline__import {
   position: relative;
   display: grid;


### PR DESCRIPTION
## Summary
- replace the favorites feed with an Instagram-inspired collections experience
- add support for creating and managing custom favorite playlists stored locally
- style the saved collections grid and detail drawer to match the new layout

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68e46f38f90483239b6319e4ce488327