### PR TITLE
Update Supabase favorite column usage

### DIFF
--- a/src/app/routers/ingest.py
+++ b/src/app/routers/ingest.py
@@ -153,7 +153,7 @@ def _recipe_from_record(record: Dict[str, Any]) -> RecipeResponse:
     duration = _to_int(ai_data.get("durationMinutes"))
     servings = _to_int(ai_data.get("servings"))
 
-    is_favorite = bool(record.get("isFavorite"))
+    is_favorite = bool(record.get("is_favorite"))
 
     difficulty_candidate = _clean_str(ai_data.get("difficulty"))
     difficulty = (
@@ -352,7 +352,7 @@ async def list_recipes(
 ) -> RecipeListResponse:
     query = (
         supa.table("recipes")
-        .select("recipe_id,title,metadata,created_at,updated_at,isFavorite", count="exact")
+        .select("recipe_id,title,metadata,created_at,updated_at,is_favorite", count="exact")
         .eq("owner_id", str(user.id))
         .order("created_at", desc=True)
     )
@@ -397,7 +397,7 @@ async def get_recipe(
 ) -> RecipeResponse:
     response = (
         supa.table("recipes")
-        .select("recipe_id,title,metadata,created_at,updated_at,isFavorite")
+        .select("recipe_id,title,metadata,created_at,updated_at,is_favorite")
         .eq("owner_id", str(user.id))
         .eq("recipe_id", recipe_id)
         .limit(1)

--- a/src/services/persist_supabase.py
+++ b/src/services/persist_supabase.py
@@ -535,7 +535,7 @@ def mark_recipe_as_favorite(
     try:
         update_response = (
             supa.table("recipes")
-            .update({"isFavorite": is_favorite})
+            .update({"is_favorite": is_favorite})
             .eq("owner_id", owner_id)
             .eq("recipe_id", recipe_id)
             .execute()
@@ -546,7 +546,7 @@ def mark_recipe_as_favorite(
         
         response = (
             supa.table("recipes")
-            .select("recipe_id,title,metadata,created_at,updated_at,isFavorite")
+            .select("recipe_id,title,metadata,created_at,updated_at,is_favorite")
             .eq("owner_id", owner_id)
             .eq("recipe_id", recipe_id)
             .limit(1)
@@ -555,7 +555,7 @@ def mark_recipe_as_favorite(
         
     except Exception as exc:
         raise RuntimeError(
-            f"Erro ao atualizar isFavorite da receita {recipe_id}: {exc}"
+            f"Erro ao atualizar is_favorite da receita {recipe_id}: {exc}"
         ) from exc
 
     records = response.data or []


### PR DESCRIPTION
## Summary
- update Supabase recipe queries to use the renamed `is_favorite` column
- keep API responses using the existing `isFavorite` camelCase field for clients

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5cbe9c1b4832389adb787f9398748