### PR TITLE
Add playlists UI and integrate frontend with playlist APIs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,8 @@ import CookingModePage from './pages/CookingModePage';
 import RecipeDetailPage from './pages/RecipeDetailPage';
 import ProfilePage from './pages/ProfilePage';
 import ChatPage from './pages/ChatPage';
+import PlaylistsPage from './pages/PlaylistsPage';
+import PlaylistDetailPage from './pages/PlaylistDetailPage';
 
 const App = () => {
   return (
@@ -34,6 +36,8 @@ const App = () => {
         <Route path="recipes/:recipeId/cook" element={<CookingModePage />} />
         <Route path="profile" element={<ProfilePage />} />
         <Route path="chat" element={<ChatPage />} />
+        <Route path="playlists" element={<PlaylistsPage />} />
+        <Route path="playlists/:playlistId" element={<PlaylistDetailPage />} />
       </Route>
 
       <Route path="*" element={<NotFoundPage />} />

--- a/frontend/src/components/layout/BottomNav.tsx
+++ b/frontend/src/components/layout/BottomNav.tsx
@@ -142,8 +142,8 @@ const BottomNav = () => {
           />
         </svg>
       ),
-      to: { pathname: '/app', search: buildSearch('favorites') },
-      isActive: location.pathname === '/app' && view === 'favorites'
+      to: '/app/playlists',
+      isActive: location.pathname.startsWith('/app/playlists')
     },
     {
       key: 'profile',

--- a/frontend/src/context/PlaylistContext.tsx
+++ b/frontend/src/context/PlaylistContext.tsx
@@ -1,0 +1,142 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
+
+import {
+  createPlaylist as createPlaylistRequest,
+  deletePlaylist as deletePlaylistRequest,
+  fetchPlaylistDetail as fetchPlaylistDetailRequest,
+  listPlaylists as listPlaylistsRequest,
+  updatePlaylist as updatePlaylistRequest
+} from '../services/playlists';
+import type { PlaylistDetail, PlaylistSummary } from '../types';
+import { ApiError } from '../services/api';
+import { useAuth } from './AuthContext';
+
+interface PlaylistContextValue {
+  playlists: PlaylistSummary[];
+  isLoading: boolean;
+  loadPlaylists: () => Promise<void>;
+  createPlaylist: (payload: { name: string; description?: string }) => Promise<PlaylistSummary | null>;
+  updatePlaylist: (
+    playlistId: string,
+    payload: { name?: string; description?: string | null }
+  ) => Promise<PlaylistSummary | null>;
+  deletePlaylist: (playlistId: string) => Promise<void>;
+  fetchPlaylistDetail: (playlistId: string) => Promise<PlaylistDetail | null>;
+}
+
+const PlaylistContext = createContext<PlaylistContextValue | undefined>(undefined);
+
+export const PlaylistProvider = ({ children }: { children: ReactNode }) => {
+  const { session } = useAuth();
+  const [playlists, setPlaylists] = useState<PlaylistSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadPlaylists = useCallback(async () => {
+    if (!session?.access_token) {
+      setPlaylists([]);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const data = await listPlaylistsRequest(session.access_token);
+      setPlaylists(Array.isArray(data) ? data : []);
+    } catch (error) {
+      console.error('Unable to load playlists', error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [session?.access_token]);
+
+  useEffect(() => {
+    void loadPlaylists();
+  }, [loadPlaylists]);
+
+  const createPlaylist = useCallback(
+    async (payload: { name: string; description?: string }) => {
+      if (!session?.access_token) {
+        return null;
+      }
+      try {
+        const created = await createPlaylistRequest(session.access_token, payload);
+        setPlaylists((prev) => [created, ...prev]);
+        return created;
+      } catch (error) {
+        console.error('Unable to create playlist', error);
+        return null;
+      }
+    },
+    [session?.access_token]
+  );
+
+  const updatePlaylist = useCallback(
+    async (playlistId: string, payload: { name?: string; description?: string | null }) => {
+      if (!session?.access_token) {
+        return null;
+      }
+      try {
+        const updated = await updatePlaylistRequest(session.access_token, playlistId, payload);
+        setPlaylists((prev) => prev.map((item) => (item.id === playlistId ? updated : item)));
+        return updated;
+      } catch (error) {
+        console.error('Unable to update playlist', error);
+        return null;
+      }
+    },
+    [session?.access_token]
+  );
+
+  const deletePlaylist = useCallback(
+    async (playlistId: string) => {
+      if (!session?.access_token) {
+        return;
+      }
+      try {
+        await deletePlaylistRequest(session.access_token, playlistId);
+        setPlaylists((prev) => prev.filter((item) => item.id !== playlistId));
+      } catch (error) {
+        console.error('Unable to delete playlist', error);
+      }
+    },
+    [session?.access_token]
+  );
+
+  const fetchPlaylistDetail = useCallback(
+    async (playlistId: string) => {
+      if (!session?.access_token) {
+        return null;
+      }
+      try {
+        return await fetchPlaylistDetailRequest(session.access_token, playlistId);
+      } catch (error) {
+        if (error instanceof ApiError && error.status === 404) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    [session?.access_token]
+  );
+
+  const value = useMemo(
+    () => ({ playlists, isLoading, loadPlaylists, createPlaylist, updatePlaylist, deletePlaylist, fetchPlaylistDetail }),
+    [createPlaylist, deletePlaylist, fetchPlaylistDetail, isLoading, loadPlaylists, playlists, updatePlaylist]
+  );
+
+  return <PlaylistContext.Provider value={value}>{children}</PlaylistContext.Provider>;
+};
+
+export const usePlaylists = () => {
+  const context = useContext(PlaylistContext);
+  if (!context) {
+    throw new Error('usePlaylists must be used within a PlaylistProvider');
+  }
+  return context;
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import App from './App';
 import { AuthProvider } from './context/AuthContext';
 import { ChatProvider } from './context/ChatContext';
 import { RecipeProvider } from './context/RecipeContext';
+import { PlaylistProvider } from './context/PlaylistContext';
 import { ThemeProvider } from './context/ThemeContext';
 
 import './index.css';
@@ -16,9 +17,11 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
       <ThemeProvider>
         <AuthProvider>
           <RecipeProvider>
-            <ChatProvider>
-              <App />
-            </ChatProvider>
+            <PlaylistProvider>
+              <ChatProvider>
+                <App />
+              </ChatProvider>
+            </PlaylistProvider>
           </RecipeProvider>
         </AuthProvider>
       </ThemeProvider>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,9 +1,8 @@
 import { FormEvent, useMemo, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 
 import Loader from '../components/shared/Loader';
 import RecipeGrid from '../components/recipes/RecipeGrid';
-import SavedCollectionsView from '../components/saved/SavedCollectionsView';
 import { useAuth } from '../context/AuthContext';
 import { useRecipes } from '../context/RecipeContext';
 import type { Recipe } from '../types';
@@ -239,15 +238,7 @@ const HomePage = () => {
   }
 
   if (view === 'favorites') {
-    return (
-      <div className="timeline timeline--favorites">
-        <SavedCollectionsView
-          favorites={favoritesCarousel}
-          onOpenRecipe={(id) => navigate(`/app/recipes/${id}`)}
-          onToggleFavorite={toggleFavorite}
-        />
-      </div>
-    );
+    return <Navigate to="/app/playlists" replace />;
   }
 
   return (

--- a/frontend/src/pages/PlaylistDetailPage.tsx
+++ b/frontend/src/pages/PlaylistDetailPage.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import RecipeGrid from '../components/recipes/RecipeGrid';
+import Loader from '../components/shared/Loader';
+import { usePlaylists } from '../context/PlaylistContext';
+import { useRecipes } from '../context/RecipeContext';
+import type { PlaylistDetail } from '../types';
+
+import './playlists.css';
+
+const FALLBACK_COVER =
+  'linear-gradient(135deg, rgba(20, 20, 20, 0.9), rgba(54, 54, 54, 0.9)), url(https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=1200&q=60)';
+
+const PlaylistDetailPage = () => {
+  const { playlistId } = useParams();
+  const navigate = useNavigate();
+  const { fetchPlaylistDetail, playlists, loadPlaylists } = usePlaylists();
+  const { toggleFavorite } = useRecipes();
+  const [detail, setDetail] = useState<PlaylistDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!playlists.length) {
+      void loadPlaylists();
+    }
+  }, [loadPlaylists, playlists.length]);
+
+  useEffect(() => {
+    if (!playlistId) {
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+
+    const loadDetail = async () => {
+      try {
+        const data = await fetchPlaylistDetail(playlistId);
+        if (!data) {
+          setError('Playlist não encontrada.');
+          setDetail(null);
+          return;
+        }
+        setDetail(data);
+      } catch (err) {
+        console.error('Unable to load playlist detail', err);
+        setError('Não foi possível carregar esta playlist. Tente novamente.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void loadDetail();
+  }, [fetchPlaylistDetail, playlistId]);
+
+  const recipes = useMemo(() => detail?.items.map((item) => item.recipe) ?? [], [detail?.items]);
+
+  const coverImage = useMemo(() => {
+    if (!detail?.items.length) {
+      return FALLBACK_COVER;
+    }
+    const firstWithCover = detail.items.find((item) => item.recipe.coverImage);
+    if (firstWithCover?.recipe.coverImage) {
+      return `linear-gradient(180deg, rgba(0, 0, 0, 0.55), rgba(0, 0, 0, 0.85)), url(${firstWithCover.recipe.coverImage})`;
+    }
+    return FALLBACK_COVER;
+  }, [detail?.items]);
+
+  const handleToggleFavorite = async (recipeId: string) => {
+    await toggleFavorite(recipeId);
+    setDetail((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      return {
+        ...prev,
+        items: prev.items.map((item) =>
+          item.recipe.id === recipeId
+            ? { ...item, recipe: { ...item.recipe, isFavorite: !item.recipe.isFavorite } }
+            : item
+        )
+      };
+    });
+    void loadPlaylists();
+  };
+
+  return (
+    <div className="playlist-detail">
+      <header className="playlist-detail__hero" style={{ backgroundImage: coverImage }}>
+        <div className="playlist-detail__hero-overlay" aria-hidden="true" />
+        <button type="button" className="playlist-detail__back" onClick={() => navigate(-1)}>
+          Voltar
+        </button>
+        <div className="playlist-detail__hero-content">
+          <p className="playlist-detail__eyebrow">Coleção</p>
+          <h1>{detail?.name ?? 'Playlist'}</h1>
+          {detail ? (
+            <p className="playlist-detail__meta">
+              {detail.recipeCount === 1
+                ? '1 receita salva'
+                : `${detail.recipeCount} receitas salvas`}
+            </p>
+          ) : null}
+          {detail?.description ? <p className="playlist-detail__description">{detail.description}</p> : null}
+        </div>
+      </header>
+
+      <div className="playlist-detail__body">
+        <nav className="playlist-detail__breadcrumbs" aria-label="Você está em">
+          <Link to="/app/playlists">Salvos</Link>
+          {detail ? <span aria-current="page">{detail.name}</span> : null}
+        </nav>
+
+        {isLoading ? (
+          <section className="playlist-detail__loading" role="status">
+            <Loader />
+            <p>Buscando receitas desta playlist...</p>
+          </section>
+        ) : null}
+
+        {error && !isLoading ? (
+          <section className="playlist-detail__error" role="alert">
+            <h2>Ops!</h2>
+            <p>{error}</p>
+          </section>
+        ) : null}
+
+        {!isLoading && !error ? (
+          <RecipeGrid
+            recipes={recipes}
+            onOpenRecipe={(id) => navigate(`/app/recipes/${id}`)}
+            onToggleFavorite={handleToggleFavorite}
+            emptyMessage="Esta playlist ainda não possui receitas."
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default PlaylistDetailPage;

--- a/frontend/src/pages/PlaylistsPage.tsx
+++ b/frontend/src/pages/PlaylistsPage.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import Loader from '../components/shared/Loader';
+import { usePlaylists } from '../context/PlaylistContext';
+
+import './playlists.css';
+
+const FALLBACK_GRADIENTS = [
+  'linear-gradient(135deg, rgba(255, 99, 132, 0.65), rgba(53, 162, 235, 0.65))',
+  'linear-gradient(135deg, rgba(255, 159, 64, 0.65), rgba(75, 192, 192, 0.65))',
+  'linear-gradient(135deg, rgba(153, 102, 255, 0.65), rgba(255, 205, 86, 0.65))'
+];
+
+const getFallbackBackground = (seed: string) => {
+  if (!seed) {
+    return FALLBACK_GRADIENTS[0];
+  }
+  const hash = seed.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
+  return FALLBACK_GRADIENTS[hash % FALLBACK_GRADIENTS.length];
+};
+
+const formatCount = (count: number) => {
+  if (count === 1) {
+    return '1 receita';
+  }
+  return `${count} receitas`;
+};
+
+const PlaylistsPage = () => {
+  const navigate = useNavigate();
+  const { playlists, isLoading, loadPlaylists } = usePlaylists();
+
+  useEffect(() => {
+    if (!playlists.length) {
+      void loadPlaylists();
+    }
+  }, [loadPlaylists, playlists.length]);
+
+  const totalRecipes = useMemo(
+    () => playlists.reduce((acc, playlist) => acc + (playlist.recipeCount ?? 0), 0),
+    [playlists]
+  );
+
+  return (
+    <div className="playlists-page">
+      <header className="playlists-page__header">
+        <div>
+          <p className="playlists-page__eyebrow">Coleção</p>
+          <h1>Salvos</h1>
+          <p className="playlists-page__subtitle">
+            Organize suas receitas favoritas em playlists temáticas e acesse tudo em um só lugar.
+          </p>
+        </div>
+        <div className="playlists-page__stats" aria-label="Resumo das playlists">
+          <span>
+            {playlists.length}
+            <small>playlists</small>
+          </span>
+          <span>
+            {totalRecipes}
+            <small>receitas</small>
+          </span>
+        </div>
+      </header>
+
+      {isLoading ? (
+        <section className="playlists-page__loading" role="status">
+          <Loader />
+          <p>Carregando suas playlists...</p>
+        </section>
+      ) : null}
+
+      {!isLoading && playlists.length === 0 ? (
+        <section className="playlists-page__empty">
+          <h2>Nenhuma playlist por aqui ainda</h2>
+          <p>As playlists serão criadas automaticamente conforme você salvar receitas favoritas.</p>
+        </section>
+      ) : null}
+
+      <div className="playlists-page__grid" role="list">
+        {playlists.map((playlist) => (
+          <button
+            key={playlist.id}
+            type="button"
+            role="listitem"
+            className="playlists-card"
+            onClick={() => navigate(`/app/playlists/${playlist.id}`)}
+          >
+            <div
+              className="playlists-card__cover"
+              style={{ backgroundImage: getFallbackBackground(playlist.id) }}
+              aria-hidden="true"
+            >
+              <span className="playlists-card__initials">{playlist.name.charAt(0).toUpperCase()}</span>
+            </div>
+            <div className="playlists-card__content">
+              <p className="playlists-card__name">{playlist.name}</p>
+              <p className="playlists-card__meta">{formatCount(playlist.recipeCount)}</p>
+              {playlist.type === 'system' ? (
+                <span className="playlists-card__badge">Playlist padrão</span>
+              ) : null}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PlaylistsPage;

--- a/frontend/src/pages/playlists.css
+++ b/frontend/src/pages/playlists.css
@@ -1,0 +1,289 @@
+.playlists-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 1.5rem 1.25rem 5rem;
+}
+
+.playlists-page__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+}
+
+.playlists-page__eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  color: var(--text-muted, rgba(255, 255, 255, 0.64));
+  margin-bottom: 0.75rem;
+}
+
+.playlists-page__header h1 {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.playlists-page__subtitle {
+  color: var(--text-muted, rgba(255, 255, 255, 0.72));
+  max-width: 28rem;
+}
+
+.playlists-page__stats {
+  display: inline-flex;
+  gap: 1.5rem;
+  padding: 1.25rem 1.75rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(18px);
+}
+
+.playlists-page__stats span {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  font-size: 1.65rem;
+  font-weight: 700;
+  min-width: 4.5rem;
+}
+
+.playlists-page__stats span small {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.playlists-page__loading,
+.playlists-page__empty {
+  display: grid;
+  place-items: center;
+  gap: 1rem;
+  padding: 3rem;
+  border-radius: 1.5rem;
+  border: 1px dashed rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  text-align: center;
+}
+
+.playlists-page__empty h2 {
+  font-size: 1.4rem;
+}
+
+.playlists-page__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+}
+
+.playlists-card {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.85rem;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  transition: transform 0.25s ease, filter 0.25s ease;
+}
+
+.playlists-card:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.85);
+  outline-offset: 4px;
+}
+
+.playlists-card:hover {
+  transform: translateY(-4px);
+}
+
+.playlists-card__cover {
+  position: relative;
+  aspect-ratio: 1 / 1;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  background-size: cover;
+  background-position: center;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.playlists-card__initials {
+  font-size: 2rem;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.95);
+  text-shadow: 0 4px 18px rgba(0, 0, 0, 0.4);
+}
+
+.playlists-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.playlists-card__name {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.playlists-card__meta {
+  color: var(--text-muted, rgba(255, 255, 255, 0.68));
+  font-size: 0.9rem;
+}
+
+.playlists-card__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  width: fit-content;
+}
+
+.playlist-detail {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.playlist-detail__hero {
+  position: relative;
+  background-size: cover;
+  background-position: center;
+  border-radius: 0 0 2.5rem 2.5rem;
+  min-height: 16rem;
+  padding: 3.5rem 2rem 3rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  color: #fff;
+}
+
+.playlist-detail__hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.45) 0%, rgba(0, 0, 0, 0.92) 100%);
+  z-index: 0;
+}
+
+.playlist-detail__hero-content {
+  position: relative;
+  z-index: 1;
+  max-width: 32rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.playlist-detail__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.75rem;
+  opacity: 0.75;
+}
+
+.playlist-detail__hero h1 {
+  font-size: 2.75rem;
+  line-height: 1.1;
+}
+
+.playlist-detail__meta {
+  font-size: 1rem;
+  opacity: 0.85;
+}
+
+.playlist-detail__description {
+  opacity: 0.75;
+  line-height: 1.4;
+}
+
+.playlist-detail__back {
+  position: absolute;
+  top: 1.25rem;
+  left: 1.5rem;
+  z-index: 1;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  font-weight: 600;
+}
+
+.playlist-detail__body {
+  padding: 2rem 1.5rem 5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.playlist-detail__breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-muted, rgba(255, 255, 255, 0.68));
+}
+
+.playlist-detail__breadcrumbs a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.playlist-detail__breadcrumbs span[aria-current='page'] {
+  color: #fff;
+  font-weight: 600;
+}
+
+.playlist-detail__loading,
+.playlist-detail__error {
+  display: grid;
+  place-items: center;
+  gap: 1rem;
+  padding: 3rem;
+  border-radius: 1.5rem;
+  border: 1px dashed rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  text-align: center;
+}
+
+.playlist-detail__error h2 {
+  font-size: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .playlists-page__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .playlists-page__stats {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .playlist-detail__hero {
+    padding: 3rem 1.5rem 2.5rem;
+  }
+
+  .playlist-detail__back {
+    left: 1rem;
+  }
+
+  .playlist-detail__body {
+    padding: 1.5rem 1rem 4rem;
+  }
+}

--- a/frontend/src/services/playlists.ts
+++ b/frontend/src/services/playlists.ts
@@ -1,0 +1,70 @@
+import { apiRequest } from './api';
+
+import type { PlaylistDetail, PlaylistSummary } from '../types';
+
+export interface PlaylistCreatePayload {
+  name: string;
+  description?: string;
+}
+
+export interface PlaylistUpdatePayload {
+  name?: string;
+  description?: string | null;
+}
+
+export const listPlaylists = async (token: string) =>
+  apiRequest<PlaylistSummary[]>('/playlists', {
+    method: 'GET',
+    authToken: token
+  });
+
+export const createPlaylist = async (token: string, payload: PlaylistCreatePayload) =>
+  apiRequest<PlaylistSummary>('/playlists', {
+    method: 'POST',
+    authToken: token,
+    body: JSON.stringify(payload)
+  });
+
+export const updatePlaylist = async (
+  token: string,
+  playlistId: string,
+  payload: PlaylistUpdatePayload
+) =>
+  apiRequest<PlaylistSummary>(`/playlists/${playlistId}`, {
+    method: 'PATCH',
+    authToken: token,
+    body: JSON.stringify(payload)
+  });
+
+export const deletePlaylist = async (token: string, playlistId: string) =>
+  apiRequest<void>(`/playlists/${playlistId}`, {
+    method: 'DELETE',
+    authToken: token
+  });
+
+export const fetchPlaylistDetail = async (token: string, playlistId: string) =>
+  apiRequest<PlaylistDetail>(`/playlists/${playlistId}/recipes`, {
+    method: 'GET',
+    authToken: token
+  });
+
+export const addRecipeToPlaylist = async (
+  token: string,
+  playlistId: string,
+  recipeId: string
+) =>
+  apiRequest(`/playlists/${playlistId}/recipes`, {
+    method: 'POST',
+    authToken: token,
+    body: JSON.stringify({ recipeId })
+  });
+
+export const removeRecipeFromPlaylist = async (
+  token: string,
+  playlistId: string,
+  recipeId: string
+) =>
+  apiRequest<void>(`/playlists/${playlistId}/recipes/${recipeId}`, {
+    method: 'DELETE',
+    authToken: token
+  });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -64,6 +64,30 @@ export interface RecipeListResponse {
   offset: number;
 }
 
+export type PlaylistType = 'system' | 'custom';
+
+export interface PlaylistSummary {
+  id: string;
+  name: string;
+  slug: string;
+  type: PlaylistType;
+  description?: string | null;
+  recipeCount: number;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+}
+
+export interface PlaylistItem {
+  recipeId: string;
+  addedAt?: string | null;
+  position?: number | null;
+  recipe: Recipe;
+}
+
+export interface PlaylistDetail extends PlaylistSummary {
+  items: PlaylistItem[];
+}
+
 export interface ChatMessage {
   id: string;
   role: 'user' | 'assistant' | 'system';


### PR DESCRIPTION
## Summary
- add a dedicated playlist context and API client to consume the new backend endpoints
- create saved playlists listing and playlist detail pages with updated styling and routing
- update application shell navigation and providers to expose the new playlists experience

## Testing
- npm run lint *(fails: ESLint configuration file is missing in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f24c01408323958460a8399f1d16